### PR TITLE
feat: add opt-in V4 Pro experiment lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # dsh-routing-suite — 注入器 × 思维模式路由 套装
 
-一个仓库装齐「运行时手术台 + 思维模式路由预设」：先装注入器（免重启运行时管理层），
-再用它装配 router-standard 预设（任务感知思维模式路由，P1-P23 实测）。
+一个仓库装齐「运行时手术台 + 思维模式路由预设 + Pro 实验台」：先装注入器（免重启运行时管理层），
+再装配 router-standard 预设（任务感知思维模式路由，P1-P23 实测），按需打开 Pro 实验臂收集可复现证据。
 
-## 安装链（三步）
+## 安装链（四步）
 
 ```powershell
 # 1. 拉套装（含两个 submodule）
 git clone --recurse-submodules https://github.com/yjh051108/dsh-routing-suite.git
 cd dsh-routing-suite
 
-# 2. 一键安装（注入器装配 + 预设复制 + 提示重启）
+# 2. 一键安装（注入器装配 + 预设复制 + Pro 实验插件 + 提示重启）
 .\install.ps1
 ```
 
@@ -24,7 +24,10 @@ dsh plugin --profile web add .\injector
 $target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-standard'
 Copy-Item -Recurse .\preset\preset $target
 
-# 步骤 3：重启 DSH → 新会话选择 Router Standard (experimental)
+# 步骤 3：安装 Pro 实验插件（默认只观测，不改变 Flash 或未知模型）
+dsh plugin --profile web add .\pro-lab
+
+# 步骤 4：重启 DSH → 新会话选择 Router Standard (experimental)
 ```
 
 ## 组件
@@ -33,10 +36,33 @@ Copy-Item -Recurse .\preset\preset $target
 |---|---|---|---|
 | `injector/` | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | [v0.3.3](https://github.com/yjh051108/dsh-super-injector/releases/tag/v0.3.3) | 运行时注入器：dev_* 工具全家桶（注入/热重载/侧挂转正/卸载/路由自愈） |
 | `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [v0.1.1](https://github.com/yjh051108/dsh-router-standard/releases/tag/v0.1.1) | 思维模式路由预设：spec/react/weak 三模式 + 近距离引导 + 单任务三锚 |
+| `pro-lab/` | 本套装插件 | `0.1.0` | Pro 实验臂、首轮 request/header 观测、schema/prompt 指纹、invalid-run 检查、脱敏 JSONL 导出 |
 
 > 版本号以各组件仓库的 git tag 为准（列内链接直达对应 Release）。
 
 两个组件独立演进（submodule 指向各自 main），套装聚合安装链与总览。
+
+## Pro 实验台
+
+`pro-lab` 默认是 `standard`：只记录 provider/model、maxTokens、工具顺序、schema 指纹、阶段、调用/错误/耗时相关计数，不自动改写请求。它只对明确识别为 V4 Pro 的模型自动启用实验观测；Flash 和未知模型保持原有 routing-suite 行为。OpenCode Go Flash 会标记为 `opencode-go-flash-quantized`，必须和官方 Flash 分开统计，不能把量化造成的轻微降智误判为路由或提示词效果。
+
+要做干净的首轮比较，建议在启动 DSH 前设置 `DSH_PRO_LAB_ARM=anchored`（替换为其他实验臂）。也可以让首条用户消息使用 `/v4 lab anchored` 选择实验臂；`dev_pro_lab_mode` 只适用于尚未 assembly 的外部预置 session。首个 assembly 后实验臂锁定，避免同一 session 中途改变变量：
+
+| 实验臂 | 首轮行为 | 晋升条件 |
+|---|---|---|
+| `standard` | 不改写 | 不适用 |
+| `anchored` | 固定 Pro prompt + 一个 shell/一个文件操作工具 | 首个持久 `tool/call` |
+| `prompt-only` | 只改 prompt，保留完整工具目录 | 不适用 |
+| `schema-only` | 只裁剪首轮工具目录 | 首个 `tool/call` |
+| `injection-suppressed` | 清空 assembled contexts | 不适用 |
+| `promote-on-tool` | 首轮窄 schema | 首个 `tool/call` |
+| `promote-on-assistant` | 首轮窄 schema | 首个 `assistant/message` |
+| `zero-tool` | 首轮空工具目录 | 仅用于对照 |
+| `whoami` / `warmup` | 身份探针 / 固定 warmup prompt | 不适用 |
+
+使用 `dev_pro_lab_status` 查看当前实验是否有效；如果首轮 schema、header 或 prompt 出现不符合实验臂的变化，会在 `invalid` 中标记。使用 `dev_pro_lab_export` 导出 JSONL。日志不会保存原始 prompt、reasoning、密钥或工具参数，默认写入 `$DSH_HOME/pro-lab/`。
+
+实验建议先做每臂 6-8 次微探针，再用不同结构的工程任务留出复验；不要把同一个 PE998 任务的大量重复运行当作因果证据。
 
 ## router-standard 预设能力（P1-P23 实测摘要）
 
@@ -51,6 +77,7 @@ Copy-Item -Recurse .\preset\preset $target
 
 - 注入器引导（规范铁律 10 条）：`injector/README.md`
 - 路由预设论文与实验：`preset/docs/paper.md` + `preset/docs/experiments.md`（P1-P23）
+- Pro 实验台设计与数据格式：`pro-lab/README.md`
 
 ## 许可证
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,5 @@
 # dsh-routing-suite 一键安装（Windows PowerShell）
-# 步骤：1) 装配注入器  2) 安装 router-standard 预设  3) 提示重启
+# 步骤：1) 装配注入器  2) 安装 router-standard 预设  3) 安装 Pro 实验插件  4) 提示重启
 $ErrorActionPreference = 'Stop'
 $root = Split-Path -Parent $MyInvocation.MyCommand.Path
 
@@ -22,8 +22,24 @@ if (Test-Path $target) {
   Write-Host "预设已安装：$target" -ForegroundColor Green
 }
 
-Write-Host '=== [3/3] 完成 ===' -ForegroundColor Cyan
+Write-Host '=== [3/4] 安装 Pro 实验插件 ===' -ForegroundColor Cyan
+$lab = Join-Path $root 'pro-lab'
+if (-not (Test-Path (Join-Path $lab 'package.json'))) {
+  Write-Host 'pro-lab 缺失，跳过（套装根目录应包含 pro-lab）' -ForegroundColor Yellow
+} elseif (-not (Get-Command dsh -ErrorAction SilentlyContinue)) {
+  Write-Host '未找到 dsh 命令，跳过 Pro 实验插件；可在 DSH 环境内执行 dsh plugin --profile web add pro-lab' -ForegroundColor Yellow
+} else {
+  & dsh plugin --profile web add $lab 2>&1 | Out-Host
+  if ($LASTEXITCODE -ne 0) {
+    Write-Host 'Pro 实验插件装配失败；不影响 injector/router-standard，见上方错误后可单独重试' -ForegroundColor Yellow
+  } else {
+    Write-Host 'Pro 实验插件已装配（默认 standard，只观测）' -ForegroundColor Green
+  }
+}
+
+Write-Host '=== [4/4] 完成 ===' -ForegroundColor Cyan
 Write-Host '1. 重启 DSH（web 服务）' -ForegroundColor Yellow
 Write-Host '2. GUI 新建会话 → 选择 Router Standard (experimental)' -ForegroundColor Yellow
 Write-Host '3. 发任务：生成任务自动 react，维护任务自动 spec，模糊任务进 weak 内路由' -ForegroundColor Yellow
-Write-Host '4. AI 自优化工具：dev_router_status / dev_router_mode / dev_mode_subagent' -ForegroundColor Yellow
+Write-Host '4. Pro 实验：首条消息使用 /v4 lab anchored（或启动前设置 DSH_PRO_LAB_ARM），再用 dev_pro_lab_status / dev_pro_lab_export 导出脱敏证据' -ForegroundColor Yellow
+Write-Host '5. AI 自优化工具：dev_router_status / dev_router_mode / dev_mode_subagent' -ForegroundColor Yellow

--- a/pro-lab/README.md
+++ b/pro-lab/README.md
@@ -1,0 +1,37 @@
+# dsh-pro-lab
+
+An opt-in experiment and evidence plugin for DeepSeek V4 Pro sessions.
+
+The default arm is `standard`. It observes the request route and session events but does not change the assembled prompt or tool catalog. Flash and unknown models are not automatically modified. A non-standard arm must be selected before the first model request with `dev_pro_lab_mode` and is then locked for the session.
+
+OpenCode Go Flash is classified as `opencode-go-flash-quantized`, a separate evidence population. It must not be pooled with official DeepSeek Flash or used as a Pro baseline: a small quantization loss can look like a routing or prompt regression if the provider populations are mixed.
+
+## Controls
+
+| Tool | Purpose |
+| --- | --- |
+| `dev_pro_lab_mode` | Select one arm before the first request |
+| `dev_pro_lab_status` | Inspect the sanitized state and invalid-run reasons |
+| `dev_pro_lab_export` | Write the current trace and summary as JSONL |
+
+Supported arms are `standard`, `anchored`, `prompt-only`, `schema-only`, `injection-suppressed`, `promote-on-tool`, `promote-on-assistant`, `zero-tool`, `whoami`, and `warmup`.
+
+For a clean first-request comparison, set `DSH_PRO_LAB_ARM=anchored` before starting DSH (replace `anchored` with another arm). A first user message exactly `/v4 lab anchored` is also recognized. The `dev_pro_lab_mode` tool is useful only before assembly in an externally prepared session; after the first assembly the arm is immutable.
+
+The first request evidence contains provider/model, max token setting when visible, ordered tool names, tool count, schema fingerprint, prompt-section shape, and context count. Later events contribute turn/step/tool/error counts and request/header snapshots. Tool arguments, prompt text, reasoning text, message content, and secrets are intentionally excluded.
+
+The process-wide append-only trace is `$DSH_HOME/pro-lab/sessions.jsonl`. `dev_pro_lab_export` writes a per-session JSONL file with a final `summary` record. Evidence writes are best-effort and never fail a user request.
+
+## Validity rules
+
+An experiment is marked invalid when the first header disagrees with the first assembled schema, a bootstrap arm exposes more than two tools, a zero-tool arm exposes any tool, contexts are not suppressed when requested, more than one schema transition occurs, or multiple known prompt writers are visible in the same assembly.
+
+These checks are diagnostics, not a quality score. Use acceptance criteria such as tests/build success, contract completion, reasonable diff, final verification, and absence of repeated/dead-end tool loops when comparing arms.
+
+## Development
+
+```powershell
+npm test
+```
+
+The plugin has no runtime dependencies beyond the DSH/Cordis host. It is a plain ESM package so the suite can install it directly with `dsh plugin --profile web add .\pro-lab`.

--- a/pro-lab/index.mjs
+++ b/pro-lab/index.mjs
@@ -1,0 +1,342 @@
+import { appendFileSync, mkdirSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { dirname, isAbsolute, join, resolve } from 'node:path'
+import {
+  ARMS,
+  DEFAULT_ARM,
+  applyArm,
+  armDescription,
+  headerSnapshot,
+  isProModel,
+  normalizeArm,
+  phaseFor,
+  routeClass,
+  schemaFingerprint,
+  stableJson,
+  toolNames,
+} from './lab-core.mjs'
+
+export const name = 'dsh-pro-lab'
+export const inject = ['systemPrompt', 'tools', 'llm']
+
+const MAX_TRACE = 2000
+
+function dshHome() {
+  return process.env.DSH_HOME || join(homedir(), '.dsh')
+}
+
+function sessionId(session) {
+  return String(session?.id ?? session?.key ?? session?.name ?? 'unknown')
+}
+
+function modelOf(agent) {
+  return String(agent?.options?.model ?? '')
+}
+
+function providerOf(agent) {
+  return String(agent?.options?.provider ?? '')
+}
+
+function userText(data) {
+  const payload = data?.message && typeof data.message === 'object' ? data.message : data
+  const content = Array.isArray(payload?.content) ? payload.content : []
+  return content.map((part) => typeof part === 'string' ? part : String(part?.text ?? '')).join(' ')
+}
+
+/** Parse an explicit preflight command from durable user events. */
+export function requestedArm(session) {
+  for (const event of session?.events ?? []) {
+    if (event?.type !== 'user/message') continue
+    const text = userText(event.data)
+    const match = text.match(/^\s*\/v4\s+(?:lab\s+)?(?:mode\s+)?([a-z0-9-]+)\s*$/i)
+    const arm = match ? normalizeArm(match[1]) : null
+    if (arm) return arm
+  }
+  return null
+}
+
+export function createSessionState(session, agent, configuredArm = null) {
+  const arm = normalizeArm(configuredArm) ?? DEFAULT_ARM
+  return {
+    id: sessionId(session),
+    arm,
+    armSource: configuredArm ? 'environment' : 'default',
+    locked: false,
+    provider: providerOf(agent) || null,
+    model: modelOf(agent) || null,
+    routeClass: routeClass(providerOf(agent), modelOf(agent)),
+    proDetected: isProModel(modelOf(agent)),
+    assemblies: 0,
+    requests: 0,
+    toolCalls: 0,
+    toolErrors: 0,
+    assistantMessages: 0,
+    turns: 0,
+    steps: 0,
+    firstAssembly: null,
+    firstHeader: null,
+    schemaFingerprints: [],
+    promptFingerprints: [],
+    invalid: [],
+    eventCounts: {},
+    trace: [],
+  }
+}
+
+function currentAgent(ctx) {
+  try { return ctx.get('agent') } catch { return undefined }
+}
+
+function stateFor(states, session, agent, configuredArm = null) {
+  const id = sessionId(session)
+  let state = states.get(id)
+  if (!state) {
+    state = createSessionState(session, agent, configuredArm)
+    states.set(id, state)
+  }
+  if (agent) {
+    state.provider ||= providerOf(agent) || null
+    state.model ||= modelOf(agent) || null
+    state.proDetected ||= isProModel(modelOf(agent))
+    if (state.routeClass === 'unknown') state.routeClass = routeClass(state.provider, state.model)
+  }
+  return state
+}
+
+function markInvalid(state, reason) {
+  if (!state.invalid.includes(reason)) state.invalid.push(reason)
+}
+
+function safeEvent(event) {
+  const type = String(event?.type ?? 'unknown')
+  const data = event?.data && typeof event.data === 'object' ? event.data : {}
+  const out = { type }
+  if (type === 'tool/call' || type === 'tool/result') {
+    out.tool = data.name ?? data.tool ?? null
+    if (type === 'tool/result') out.error = Boolean(data.isError ?? data.error)
+  }
+  if (type === 'request/header') out.header = headerSnapshot(event)
+  return out
+}
+
+function summary(state) {
+  return {
+    session: state.id,
+    arm: state.arm,
+    armSource: state.armSource,
+    locked: state.locked,
+    phase: phaseFor(state.arm, state),
+    provider: state.provider,
+    model: state.model,
+    routeClass: state.routeClass,
+    proDetected: state.proDetected,
+    invalid: [...state.invalid],
+    counts: {
+      assemblies: state.assemblies,
+      requests: state.requests,
+      turns: state.turns,
+      steps: state.steps,
+      assistantMessages: state.assistantMessages,
+      toolCalls: state.toolCalls,
+      toolErrors: state.toolErrors,
+    },
+    firstAssembly: state.firstAssembly,
+    firstHeader: state.firstHeader,
+    schemaFingerprints: [...state.schemaFingerprints],
+    promptFingerprints: [...state.promptFingerprints],
+    eventCounts: { ...state.eventCounts },
+  }
+}
+
+function exportPath(value, stateId) {
+  if (value) return isAbsolute(String(value)) ? String(value) : resolve(String(value))
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+  return join(dshHome(), 'pro-lab', `session-${stateId}-${stamp}.jsonl`)
+}
+
+export function apply(ctx) {
+  const states = new Map()
+  const configuredArm = normalizeArm(process.env.DSH_PRO_LAB_ARM)
+  const logFile = join(dshHome(), 'pro-lab', 'sessions.jsonl')
+  let activeSession = null
+
+  function appendTrace(state, record) {
+    const line = { ts: new Date().toISOString(), ...record }
+    state.trace.push(line)
+    if (state.trace.length > MAX_TRACE) state.trace.shift()
+    try {
+      mkdirSync(dirname(logFile), { recursive: true })
+      appendFileSync(logFile, stableJson({ ...line, session: state.id, arm: state.arm }) + '\n', 'utf8')
+    } catch {
+      // Evidence collection must never break the user request.
+    }
+  }
+
+  ctx.on('system-prompt/assemble', async (_assembly, context, next) => {
+    const assembled = await next()
+    const agent = context?.agent
+    const session = agent?.session
+    if (!session) return assembled
+    const state = stateFor(states, session, agent, requestedArm(session) ?? configuredArm)
+    activeSession = state.id
+    state.assemblies += 1
+    state.provider ||= providerOf(agent) || null
+    state.model ||= modelOf(agent) || null
+    state.proDetected ||= isProModel(modelOf(agent))
+
+    const beforePrompt = (assembled.sections ?? []).map((section) => ({ name: section.name, order: section.order, textLength: String(section.text ?? '').length }))
+    if (beforePrompt.filter((section) => /router-persona|pro-lab-persona/i.test(String(section.name))).length > 1) {
+      markInvalid(state, 'multiple-prompt-writers-visible')
+    }
+
+    const phase = phaseFor(state.arm, state)
+    const output = state.proDetected || state.arm !== DEFAULT_ARM
+      ? applyArm(assembled, state.arm, phase)
+      : assembled
+    const outputNames = toolNames(output.tools)
+    const schema = schemaFingerprint(output.tools)
+    const prompt = (output.sections ?? []).map((section) => ({ name: section.name, order: section.order, textLength: String(section.text ?? '').length }))
+    state.schemaFingerprints.push(schema)
+    state.promptFingerprints.push(schemaFingerprint(prompt))
+    if (state.schemaFingerprints.length > 1 && new Set(state.schemaFingerprints).size > 2) {
+      markInvalid(state, 'schema-changed-more-than-once')
+    }
+    if (!state.firstAssembly) {
+      state.firstAssembly = {
+        phase,
+        toolCount: outputNames.length,
+        tools: outputNames,
+        schema,
+        contexts: Array.isArray(output.contexts) ? output.contexts.length : null,
+      }
+      if (state.arm !== DEFAULT_ARM) {
+        if (['anchored', 'schema-only', 'promote-on-tool', 'promote-on-assistant'].includes(state.arm) && outputNames.length > 2) markInvalid(state, 'bootstrap-tool-count-too-large')
+        if (state.arm === 'zero-tool' && outputNames.length !== 0) markInvalid(state, 'zero-tool-arm-exposed-tools')
+        if (state.arm === 'injection-suppressed' && Array.isArray(output.contexts) && output.contexts.length !== 0) markInvalid(state, 'contexts-not-suppressed')
+      }
+    }
+    state.locked = true
+    appendTrace(state, { type: 'assembly', phase, toolCount: outputNames.length, tools: outputNames, schema })
+    return output
+  })
+
+  ctx.on('llm/stream', (options, next) => {
+    const state = activeSession ? states.get(activeSession) : null
+    if (state) {
+      state.provider ||= options?.provider ?? null
+      state.model ||= options?.model ?? null
+      state.proDetected ||= isProModel(state.model)
+      state.routeClass = routeClass(state.provider, state.model)
+      appendTrace(state, {
+        type: 'route',
+        provider: options?.provider ?? null,
+        model: options?.model ?? null,
+        routeClass: state.routeClass,
+        maxTokens: options?.maxTokens ?? options?.max_tokens ?? null,
+      })
+    }
+    return next()
+  })
+
+  ctx.on('session/event', (session, event) => {
+    if (!session) return
+    const agent = currentAgent(ctx)
+    const state = stateFor(states, session, agent, requestedArm(session) ?? configuredArm)
+    activeSession = state.id
+    state.routeClass = routeClass(state.provider, state.model)
+    const type = String(event?.type ?? 'unknown')
+    state.eventCounts[type] = (state.eventCounts[type] ?? 0) + 1
+    if (type === 'request/header') {
+      state.requests += 1
+      const header = headerSnapshot(event)
+      if (!state.firstHeader) {
+        state.firstHeader = header
+        if (state.firstAssembly && (state.firstAssembly.schema !== header.schema || state.firstAssembly.toolCount !== header.toolCount)) markInvalid(state, 'header-schema-mismatch')
+      }
+    } else if (type === 'tool/call') {
+      state.toolCalls += 1
+    } else if (type === 'tool/result') {
+      if (safeEvent(event).error) state.toolErrors += 1
+    } else if (type === 'assistant/message') {
+      state.assistantMessages += 1
+    } else if (type === 'turn/start') {
+      state.turns += 1
+    } else if (type === 'step/start') {
+      state.steps += 1
+    }
+    appendTrace(state, safeEvent(event))
+  })
+
+  function currentState() {
+    return activeSession ? states.get(activeSession) : null
+  }
+
+  function register(tool) {
+    ctx.effect(() => ctx.tools.register({
+      ...tool,
+      parameters: toJsonSchema(tool.parameters),
+    }))
+  }
+
+  register({
+    name: 'dev_pro_lab_mode',
+    description: 'Select an opt-in DeepSeek V4 Pro experiment arm before the first request; mode is locked after assembly.',
+    parameters: { arm: { type: 'string', required: true, description: ARMS.join(' / ') } },
+    output: { schema: { type: 'string' }, render: (_args, value) => [{ type: 'text', text: String(value) }] },
+    execute(args) {
+      const state = currentState()
+      const arm = normalizeArm(args?.arm)
+      if (!state) return 'no active agent session'
+      if (!arm) return `invalid arm; use one of: ${ARMS.join(', ')}`
+      if (state.locked && state.arm !== arm) return `arm is locked to ${state.arm} after the first request`
+      if (!state.proDetected && arm !== DEFAULT_ARM) return 'Pro lab arms are disabled for non-Pro or unknown models; use standard to observe'
+      state.arm = arm
+      state.armSource = 'manual'
+      return `arm=${arm}; ${armDescription(arm)}; applies on the next request`
+    },
+  })
+
+  register({
+    name: 'dev_pro_lab_status',
+    description: 'Show sanitized Pro lab state: arm, route, phase, schema fingerprints, counts, and invalid-run reasons.',
+    parameters: {},
+    output: { schema: { type: 'string' }, render: (_args, value) => [{ type: 'text', text: String(value) }] },
+    execute() {
+      const state = currentState()
+      return JSON.stringify(state ? summary(state) : { error: 'no active agent session' }, null, 2)
+    },
+  })
+
+  register({
+    name: 'dev_pro_lab_export',
+    description: 'Export the current session as sanitized JSONL. Raw prompt, reasoning, tool arguments, and secrets are excluded.',
+    parameters: { path: { type: 'string', description: 'optional absolute or relative output path' } },
+    output: { schema: { type: 'string' }, render: (_args, value) => [{ type: 'text', text: String(value) }] },
+    execute(args) {
+      const state = currentState()
+      if (!state) return 'no active agent session'
+      const target = exportPath(args?.path, state.id.replace(/[^a-zA-Z0-9_.-]/g, '_'))
+      try {
+        mkdirSync(dirname(target), { recursive: true })
+        const lines = [...state.trace, { type: 'summary', ...summary(state) }]
+        writeFileSync(target, lines.map((line) => stableJson(line)).join('\n') + '\n', 'utf8')
+        return `exported ${lines.length} records to ${target}`
+      } catch (error) {
+        return `export failed: ${String(error).slice(0, 240)}`
+      }
+    },
+  })
+}
+
+function toJsonSchema(spec) {
+  const properties = {}
+  const required = []
+  for (const [key, meta] of Object.entries(spec ?? {})) {
+    const prop = { type: meta.type }
+    if (Array.isArray(meta.enum)) prop.enum = meta.enum
+    if (meta.description) prop.description = meta.description
+    properties[key] = prop
+    if (meta.required) required.push(key)
+  }
+  return { type: 'object', properties, required, additionalProperties: false }
+}

--- a/pro-lab/lab-core.mjs
+++ b/pro-lab/lab-core.mjs
@@ -1,0 +1,210 @@
+import { createHash } from 'node:crypto'
+
+export const DEFAULT_ARM = 'standard'
+
+export const ARMS = Object.freeze([
+  'standard',
+  'anchored',
+  'prompt-only',
+  'schema-only',
+  'injection-suppressed',
+  'promote-on-tool',
+  'promote-on-assistant',
+  'zero-tool',
+  'whoami',
+  'warmup',
+])
+
+const ALIASES = new Map([
+  ['baseline', 'standard'],
+  ['minimal', 'anchored'],
+  ['anchor', 'anchored'],
+  ['prompt', 'prompt-only'],
+  ['schema', 'schema-only'],
+  ['suppress', 'injection-suppressed'],
+  ['tool', 'promote-on-tool'],
+  ['assistant', 'promote-on-assistant'],
+  ['zero', 'zero-tool'],
+])
+
+export function normalizeArm(value) {
+  const token = String(value ?? '').trim().toLowerCase()
+  const normalized = ALIASES.get(token) ?? token
+  return ARMS.includes(normalized) ? normalized : null
+}
+
+/** Pro matching is deliberately conservative: Flash and unknown models are untouched. */
+export function isProModel(model) {
+  if (typeof model !== 'string' || /flash/i.test(model)) return false
+  const value = model.toLowerCase()
+  const family = /(?:^|[-_. /])v?4(?:[-_. /]|$)/i.test(value) || /deepseekv4/i.test(value)
+  const pro = /(?:^|[-_. /])pro(?:$|[-_. /])/i.test(value) || /v4pro/i.test(value)
+  return family && pro
+}
+
+export function isFlashModel(model) {
+  return typeof model === 'string' && /flash/i.test(model)
+}
+
+function isOpenCodeGo(provider, model) {
+  return /opencode[-_. /]?go/i.test(`${provider ?? ''} ${model ?? ''}`)
+}
+
+/** Keep quantized OpenCode Go Flash out of official-Flash aggregates. */
+export function routeClass(provider, model) {
+  const p = String(provider ?? '')
+  const m = String(model ?? '')
+  if (isOpenCodeGo(p, m) && isFlashModel(m)) return 'opencode-go-flash-quantized'
+  if (/deepseek/i.test(p) && isFlashModel(m)) return 'deepseek-flash'
+  if (isOpenCodeGo(p, m) && isProModel(m)) return 'opencode-go-pro'
+  if (isProModel(m)) return 'pro-compatible'
+  if (isFlashModel(m)) return 'flash-unknown-provider'
+  return 'unknown'
+}
+
+export function stableValue(value, seen = new WeakSet()) {
+  if (value === null || typeof value !== 'object') {
+    if (typeof value === 'bigint') return String(value)
+    if (typeof value === 'function' || typeof value === 'symbol') return undefined
+    return value
+  }
+  if (seen.has(value)) return '[Circular]'
+  seen.add(value)
+  if (Array.isArray(value)) return value.map((item) => stableValue(item, seen))
+  const out = {}
+  for (const key of Object.keys(value).sort()) {
+    const item = stableValue(value[key], seen)
+    if (item !== undefined) out[key] = item
+  }
+  return out
+}
+
+export function stableJson(value) {
+  return JSON.stringify(stableValue(value))
+}
+
+export function fingerprint(value) {
+  return createHash('sha256').update(stableJson(value)).digest('hex').slice(0, 16)
+}
+
+export function toolName(tool) {
+  if (typeof tool === 'string') return tool
+  if (!tool || typeof tool !== 'object') return null
+  return tool.name ?? tool.function?.name ?? tool.tool?.name ?? null
+}
+
+export function toolNames(tools) {
+  return (Array.isArray(tools) ? tools : [])
+    .map(toolName)
+    .filter((name) => typeof name === 'string' && name.length > 0)
+}
+
+export function toolSchema(tool) {
+  if (typeof tool === 'string' || !tool || typeof tool !== 'object') return null
+  return tool.parameters ?? tool.function?.parameters ?? tool.inputSchema ?? tool.schema ?? null
+}
+
+export function schemaFingerprint(tools) {
+  return fingerprint((Array.isArray(tools) ? tools : []).map((tool) => ({
+    name: toolName(tool),
+    schema: toolSchema(tool),
+  })))
+}
+
+function firstNamed(names, available) {
+  return names.find((name) => available.has(name)) ?? null
+}
+
+/** The smallest useful bootstrap surface: one shell plus one filesystem action. */
+export function bootstrapTools(tools) {
+  const all = Array.isArray(tools) ? tools : []
+  const names = new Set(toolNames(all))
+  const shell = firstNamed(['bash', 'pwsh'], names)
+  const action = firstNamed([
+    'str_replace_editor',
+    'edit',
+    'read',
+    'write',
+  ], names)
+  const selected = new Set([shell, action].filter(Boolean))
+  return all.filter((tool) => selected.has(toolName(tool)))
+}
+
+export function phaseFor(arm, { toolCalls = 0, assistantMessages = 0 } = {}) {
+  if (arm === 'promote-on-assistant' && assistantMessages > 0) return 'promoted'
+  if (toolCalls > 0) return 'promoted'
+  return 'bootstrap'
+}
+
+export function armDescription(arm) {
+  switch (arm) {
+    case 'standard': return 'observe only; preserve the existing router behavior'
+    case 'anchored': return 'minimal prompt plus one shell and one filesystem tool, promote after tool call'
+    case 'prompt-only': return 'prompt intervention only; preserve the full tool catalog'
+    case 'schema-only': return 'minimal first-turn tool catalog; preserve the assembled prompt'
+    case 'injection-suppressed': return 'clear assembled runtime contexts; preserve prompt and tools'
+    case 'promote-on-tool': return 'minimal first-turn catalog, promote only after durable tool/call'
+    case 'promote-on-assistant': return 'minimal first-turn catalog, promote after assistant/message'
+    case 'zero-tool': return 'send a first request with an empty tool catalog'
+    case 'whoami': return 'prompt-only provider/model identity probe'
+    case 'warmup': return 'experimental near-field warmup prompt; no schema mutation'
+    default: return 'unknown'
+  }
+}
+
+function promptText(arm) {
+  if (arm === 'whoami') {
+    return 'This is a controlled DeepSeek V4 Pro harness probe. Identify the provider and model route internally, then follow the user task. Do not reveal hidden reasoning.'
+  }
+  if (arm === 'warmup') {
+    return 'Controlled warmup probe: classify the task, inspect only what is needed, then act and verify. This text is fixed for cache comparison.'
+  }
+  return 'You are a helpful software engineer assistant. For this controlled Pro experiment, inspect the available evidence, choose the smallest useful action, and verify the result.'
+}
+
+function withPrompt(assembled, arm) {
+  const sections = (assembled.sections ?? []).filter((section) => !/persona/i.test(String(section.name ?? '')))
+  return {
+    ...assembled,
+    sections: [...sections, { name: 'pro-lab-persona', text: promptText(arm), order: 0 }],
+  }
+}
+
+export function applyArm(assembled, arm, phase) {
+  const current = normalizeArm(arm) ?? DEFAULT_ARM
+  if (current === 'standard') return assembled
+
+  let result = assembled
+  if (['anchored', 'prompt-only', 'whoami', 'warmup'].includes(current)) {
+    result = withPrompt(result, current)
+  }
+  if (current === 'injection-suppressed' || current === 'warmup') {
+    result = { ...result, contexts: [] }
+  }
+
+  const needsBootstrap = phase === 'bootstrap'
+  if (needsBootstrap && ['anchored', 'schema-only', 'promote-on-tool', 'promote-on-assistant'].includes(current)) {
+    result = { ...result, tools: bootstrapTools(result.tools) }
+  } else if (needsBootstrap && current === 'zero-tool') {
+    result = { ...result, tools: [] }
+  }
+  return result
+}
+
+export function headerSnapshot(eventOrData) {
+  const source = eventOrData?.data && typeof eventOrData.data === 'object'
+    ? eventOrData.data
+    : (eventOrData ?? {})
+  const request = source.request && typeof source.request === 'object' ? source.request : source
+  const tools = request.tools ?? source.tools ?? []
+  const names = toolNames(tools)
+  return {
+    provider: request.provider ?? source.provider ?? request.route?.provider ?? null,
+    model: request.model ?? source.model ?? request.route?.model ?? null,
+    maxTokens: request.maxTokens ?? request.max_tokens ?? source.maxTokens ?? source.max_tokens ?? null,
+    toolCount: names.length,
+    tools: names,
+    schema: schemaFingerprint(tools),
+    routeClass: routeClass(request.provider ?? source.provider ?? request.route?.provider, request.model ?? source.model ?? request.route?.model),
+  }
+}

--- a/pro-lab/package.json
+++ b/pro-lab/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@dsh-routing-suite/pro-lab",
+  "version": "0.1.0",
+  "description": "Opt-in DeepSeek V4 Pro experiment arms and sanitized trajectory evidence for dsh-routing-suite",
+  "type": "module",
+  "main": "./index.mjs",
+  "exports": {
+    ".": "./index.mjs",
+    "./core": "./lab-core.mjs"
+  },
+  "files": [
+    "index.mjs",
+    "lab-core.mjs",
+    "README.md",
+    "test.mjs",
+    "package.json"
+  ],
+  "license": "MIT",
+  "peerDependencies": {
+    "cordis": ">=4.0.0-rc <5",
+    "@deepseek-ai/dsh-tools": ">=0.0.1-rc <2"
+  },
+  "scripts": {
+    "test": "node --test test.mjs"
+  }
+}

--- a/pro-lab/test.mjs
+++ b/pro-lab/test.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  ARMS,
+  applyArm,
+  bootstrapTools,
+  fingerprint,
+  headerSnapshot,
+  isProModel,
+  normalizeArm,
+  phaseFor,
+  routeClass,
+  schemaFingerprint,
+} from './lab-core.mjs'
+import { apply as applyPlugin, requestedArm } from './index.mjs'
+
+const tools = [
+  { name: 'bash', parameters: { type: 'object' } },
+  { name: 'str_replace_editor', parameters: { type: 'object', properties: { path: { type: 'string' } } } },
+  { name: 'glob', parameters: { type: 'object' } },
+]
+
+test('arm registry is explicit and aliases are stable', () => {
+  assert.ok(ARMS.includes('anchored'))
+  assert.equal(normalizeArm('baseline'), 'standard')
+  assert.equal(normalizeArm('minimal'), 'anchored')
+  assert.equal(normalizeArm('nope'), null)
+})
+
+test('Pro detection never opts Flash or unknown models into experiments', () => {
+  assert.equal(isProModel('deepseek-v4-pro'), true)
+  assert.equal(isProModel('deepseek-v3-pro'), false)
+  assert.equal(isProModel('deepseek-v4-flash'), false)
+  assert.equal(isProModel('custom-provider/model'), false)
+})
+
+test('OpenCode Go quantized Flash is a separate evidence population', () => {
+  assert.equal(routeClass('opencode-go', 'deepseek-v4-flash'), 'opencode-go-flash-quantized')
+  assert.equal(routeClass('deepseek', 'deepseek-v4-flash'), 'deepseek-flash')
+  assert.equal(routeClass('opencode-go', 'deepseek-v4-pro'), 'opencode-go-pro')
+  assert.equal(routeClass('custom-provider', 'deepseek-v4-flash'), 'flash-unknown-provider')
+})
+
+test('bootstrap surface keeps one shell and one filesystem action', () => {
+  assert.deepEqual(bootstrapTools(tools).map((tool) => tool.name), ['bash', 'str_replace_editor'])
+  assert.deepEqual(bootstrapTools([{ name: 'glob' }]).map((tool) => tool.name), [])
+})
+
+test('anchored arm changes tools once and promotes after a durable call', () => {
+  const assembly = { sections: [{ name: 'router-persona', text: 'old' }], contexts: [{ id: 1 }], tools }
+  const first = applyArm(assembly, 'anchored', phaseFor('anchored', { toolCalls: 0 }))
+  assert.deepEqual(first.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
+  assert.equal(first.contexts.length, 1)
+  assert.equal(first.sections[0].name, 'pro-lab-persona')
+  const promoted = applyArm(assembly, 'anchored', phaseFor('anchored', { toolCalls: 1 }))
+  assert.equal(promoted.tools.length, tools.length)
+})
+
+test('schema-only and zero-tool arms do not inject prompt text', () => {
+  const assembly = { sections: [{ name: 'persona', text: 'keep' }], contexts: [], tools }
+  const schema = applyArm(assembly, 'schema-only', 'bootstrap')
+  assert.equal(schema.sections[0].name, 'persona')
+  assert.equal(schema.tools.length, 2)
+  const zero = applyArm(assembly, 'zero-tool', 'bootstrap')
+  assert.equal(zero.tools.length, 0)
+})
+
+test('header snapshots expose metadata and a schema fingerprint only', () => {
+  const header = headerSnapshot({ type: 'request/header', data: { provider: 'deepseek', model: 'deepseek-v4-pro', max_tokens: 4096, tools } })
+  assert.deepEqual(header.tools, ['bash', 'str_replace_editor', 'glob'])
+  assert.equal(header.toolCount, 3)
+  assert.equal(header.maxTokens, 4096)
+  assert.equal(header.schema, schemaFingerprint(tools))
+  assert.equal(Object.hasOwn(header, 'prompt'), false)
+  assert.notEqual(fingerprint(tools), fingerprint([{ name: 'other' }]))
+})
+
+test('preflight command selects an arm before the first model request', () => {
+  const session = {
+    events: [
+      { type: 'user/message', data: { content: [{ type: 'text', text: '/v4 lab anchored' }] } },
+    ],
+  }
+  assert.equal(requestedArm(session), 'anchored')
+  assert.equal(requestedArm({ events: [{ type: 'user/message', data: { content: [{ type: 'text', text: 'anchored' }] } }] }), null)
+})
+
+test('plugin integration locks the arm and exports sanitized evidence', async () => {
+  const oldHome = process.env.DSH_HOME
+  const home = mkdtempSync(join(tmpdir(), 'dsh-pro-lab-'))
+  process.env.DSH_HOME = home
+  const handlers = new Map()
+  const registered = []
+  const ctx = {
+    on(event, handler) { handlers.set(event, handler) },
+    effect(register) { return register() },
+    tools: { register(tool) { registered.push(tool); return () => {} } },
+    get() { throw new Error('no global agent in fixture') },
+  }
+  try {
+    applyPlugin(ctx)
+    assert.deepEqual(registered.map((tool) => tool.name), ['dev_pro_lab_mode', 'dev_pro_lab_status', 'dev_pro_lab_export'])
+    const session = { id: 'fixture', events: [{ type: 'user/message', data: { content: [{ type: 'text', text: '/v4 lab anchored' }] } }] }
+    const agent = { session, options: { provider: 'deepseek', model: 'deepseek-v4-pro' } }
+    const assembly = { sections: [{ name: 'router-persona', text: 'old' }], contexts: [{ id: 'runtime' }], tools }
+    const first = await handlers.get('system-prompt/assemble')({}, { agent }, async () => assembly)
+    assert.deepEqual(first.tools.map((tool) => tool.name), ['bash', 'str_replace_editor'])
+    handlers.get('session/event')(session, { type: 'request/header', data: { provider: 'deepseek', model: 'deepseek-v4-pro', tools: first.tools } })
+    const status = JSON.parse(await registered[1].execute({}))
+    assert.equal(status.arm, 'anchored')
+    assert.equal(status.locked, true)
+    assert.equal(status.invalid.length, 0)
+    assert.match(await registered[0].execute({ arm: 'schema-only' }), /locked/)
+    const target = join(home, 'fixture.jsonl')
+    assert.match(await registered[2].execute({ path: target }), /exported/)
+    const exported = readFileSync(target, 'utf8')
+    assert.equal(exported.includes('raw prompt'), false)
+    assert.equal(exported.includes('reasoning_content'), false)
+  } finally {
+    if (oldHome === undefined) delete process.env.DSH_HOME
+    else process.env.DSH_HOME = oldHome
+    rmSync(home, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## What this adds

- Adds `pro-lab`, a standalone opt-in DSH plugin for controlled DeepSeek V4 Pro experiment arms.
- Captures sanitized first-request evidence: provider/model, max tokens when visible, ordered tool names, schema fingerprints, prompt-section shape, context count, phase transitions, tool/error/turn/step counts.
- Marks invalid runs for schema/header mismatch, oversized bootstrap surfaces, unexpected context/tool exposure, repeated schema changes, and multiple visible prompt writers.
- Adds `dev_pro_lab_mode`, `dev_pro_lab_status`, and `dev_pro_lab_export`; the arm is immutable after the first assembly.
- Keeps existing Flash/router behavior unchanged by default. OpenCode Go Flash is classified separately as `opencode-go-flash-quantized` so quantization effects are not mixed with official Flash or Pro results.

## Experiment arms

`standard`, `anchored`, `prompt-only`, `schema-only`, `injection-suppressed`, `promote-on-tool`, `promote-on-assistant`, `zero-tool`, `whoami`, and `warmup`.

A clean first-request arm can be selected with `DSH_PRO_LAB_ARM` before launch or `/v4 lab <arm>` as the first durable user message. Raw prompt, reasoning, tool arguments, and secrets are not persisted.

## Compatibility

- Existing `injector/` and `preset/` submodule pointers are unchanged.
- Pro lab defaults to observation-only; non-Pro/unknown models are not automatically modified.
- The installer adds the plugin as a fourth step but tolerates an unavailable `dsh` command.

## Verification

- `pro-lab`: 9/9 tests passed.
- `preset`: 15/15 tests passed.
- `node --check` passed for plugin modules.
- PowerShell parse check passed for `install.ps1`.