### PR TITLE
fix(install): copy each router preset directory separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## 安装链（三步）
 
 ```powershell
-# 1. 拉套装（含两个 submodule）
+# 1. 拉套装（含三个 submodule）
 git clone --recurse-submodules https://github.com/yjh051108/dsh-routing-suite.git
 cd dsh-routing-suite
 
@@ -22,9 +22,15 @@ cd dsh-routing-suite
 # 步骤 1：装配注入器（官方装配，重启后由 bundles 接管）
 dsh plugin --profile web add .\injector
 
-# 步骤 2：安装 router-standard 预设
+# 步骤 2：安装路由预设（router-standard / router-spec / router-pro）
 $target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-standard'
-Copy-Item -Recurse .\preset\preset $target
+Copy-Item -Recurse .\preset\preset\router-standard $target
+
+$target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-spec'
+Copy-Item -Recurse .\preset\preset\router-spec $target
+
+$target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-pro'
+Copy-Item -Recurse .\preset\preset\router-pro $target
 
 # 步骤 3：重启 DSH → 新会话选择 Router Standard (experimental)
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -12,14 +12,17 @@ if (-not (Test-Path (Join-Path $injector 'lib\index.js'))) {
   Write-Host '注入器已装配（重启后由 bundles 接管）' -ForegroundColor Green
 }
 
-Write-Host '=== [2/3] 安装 router-standard 预设 ===' -ForegroundColor Cyan
-$target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-standard'
-if (Test-Path $target) {
-  Write-Host "预设已存在：$target（如需覆盖请先手动删除）" -ForegroundColor Yellow
-} else {
-  New-Item -ItemType Directory -Force -Path (Split-Path $target) | Out-Null
-  Copy-Item -Recurse (Join-Path $root 'preset\preset') $target
-  Write-Host "预设已安装：$target" -ForegroundColor Green
+Write-Host '=== [2/3] 安装路由预设（router-standard / router-spec / router-pro） ===' -ForegroundColor Cyan
+$presets = @('router-standard', 'router-spec', 'router-pro')
+foreach ($name in $presets) {
+  $target = Join-Path $env:USERPROFILE ".dsh\.agent-presets\$name"
+  if (Test-Path $target) {
+    Write-Host "预设已存在：$target（如需覆盖请先手动删除）" -ForegroundColor Yellow
+  } else {
+    New-Item -ItemType Directory -Force -Path (Split-Path $target) | Out-Null
+    Copy-Item -Recurse (Join-Path $root "preset\preset\$name") $target
+    Write-Host "预设已安装：$target" -ForegroundColor Green
+  }
 }
 
 Write-Host '=== [3/3] 完成 ===' -ForegroundColor Cyan


### PR DESCRIPTION
## 问题

`install.ps1` 和 `README.md` 手动安装步骤使用：

```powershell
Copy-Item -Recurse .\preset\preset $target
```

当目标 `~/.dsh/.agent-presets/router-standard` 不存在时，这会把 `preset/preset` 下的 **router-standard / router-spec / router-pro 三个子目录整体复制进 `router-standard`**，导致该目录不是一个合法预设（缺少顶层 `agent.cordis.yml`）。

## 修复

- `install.ps1`：改为分别复制 `router-standard`、`router-spec`、`router-pro` 三个预设子目录；
- `README.md`：手动安装命令同步改为逐个复制；
- 顺带把“含两个 submodule”更正为“含三个 submodule”；
- 将 `preset` submodule 指针更新到 [dsh-router-standard#12](https://github.com/yjh051108/dsh-router-standard/pull/12) 的提交，使套装克隆默认携带 `preset.yml` 描述修复。

## 关联 PR

- [dsh-router-standard#12](https://github.com/yjh051108/dsh-router-standard/pull/12)：修复 Router Standard / Router Spec 的 `preset.yml` YAML 解析失败问题。