### PR TITLE
Fix Windows PowerShell installer compatibility

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -23,6 +23,10 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
 PowerShell 5.1 when the script contains non-ASCII text. PowerShell 7 users can
 also run `pwsh -File .\install.ps1` directly.
 
+The one-shot installer stops with an actionable error if `dsh` is unavailable
+or `injector/lib/index.js` has not been built. It reports completion only after
+the injector and both routing presets have been installed successfully.
+
 Or manually:
 
 ```powershell

--- a/README.en.md
+++ b/README.en.md
@@ -15,8 +15,13 @@ git clone --recurse-submodules https://github.com/yjh051108/dsh-routing-suite.gi
 cd dsh-routing-suite
 
 # 2. One-shot install (injector assembly + preset copy + restart prompt)
-.\install.ps1
+# -ExecutionPolicy Bypass applies only to this PowerShell process; it does not change the system policy
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
 ```
+
+`install.ps1` is encoded as UTF-8 with BOM for compatibility with Windows
+PowerShell 5.1 when the script contains non-ASCII text. PowerShell 7 users can
+also run `pwsh -File .\install.ps1` directly.
 
 Or manually:
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ git clone --recurse-submodules https://github.com/yjh051108/dsh-routing-suite.gi
 cd dsh-routing-suite
 
 # 2. 一键安装（注入器装配 + 预设复制 + 提示重启）
-.\install.ps1
+# -ExecutionPolicy Bypass 仅对此次 PowerShell 进程生效，不修改系统策略
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
 ```
+
+`install.ps1` 使用带 BOM 的 UTF-8 编码，以兼容含中文内容的 Windows PowerShell 5.1；
+PowerShell 7 用户也可以直接运行 `pwsh -File .\install.ps1`。
 
 或手动：
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,14 @@ PowerShell 7 用户也可以直接运行 `pwsh -File .\install.ps1`。
 # 步骤 1：装配注入器（官方装配，重启后由 bundles 接管）
 dsh plugin --profile web add .\injector
 
-# 步骤 2：安装 router-standard 预设
+# 步骤 2：安装路由预设
 $target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-standard'
-Copy-Item -Recurse .\preset\preset $target
+Copy-Item -Recurse .\preset\preset\router-standard $target
 
-# 步骤 3：重启 DSH → 新会话选择 Router Standard (experimental)
+$target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-spec'
+Copy-Item -Recurse .\preset\preset\router-spec $target
+
+# 步骤 3：重启 DSH → 新会话选择 Router Standard / Router Spec
 ```
 
 ## 组件

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-# dsh-routing-suite 一键安装（Windows PowerShell）
+﻿# dsh-routing-suite 一键安装（Windows PowerShell）
 # 步骤：1) 装配注入器  2) 安装 router-standard 预设  3) 提示重启
 $ErrorActionPreference = 'Stop'
 $root = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/install.ps1
+++ b/install.ps1
@@ -1,29 +1,52 @@
 ﻿# dsh-routing-suite 一键安装（Windows PowerShell）
-# 步骤：1) 装配注入器  2) 安装 router-standard 预设  3) 提示重启
+# 步骤：1) 检查依赖并装配注入器  2) 安装路由预设  3) 提示重启
 $ErrorActionPreference = 'Stop'
 $root = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 Write-Host '=== [1/3] 装配注入器 ===' -ForegroundColor Cyan
 $injector = Join-Path $root 'injector'
 if (-not (Test-Path (Join-Path $injector 'lib\index.js'))) {
-  Write-Host 'injector/lib 缺失——先构建：cd injector; bash scripts/build.sh（需 DSH_CHECKOUT）或从 Release 下载 tgz' -ForegroundColor Yellow
-} else {
-  & dsh plugin --profile web add $injector 2>&1 | Out-Host
-  Write-Host '注入器已装配（重启后由 bundles 接管）' -ForegroundColor Green
+  throw 'injector/lib/index.js 缺失。请先构建 injector（需 DSH_CHECKOUT），或使用包含 lib 的 Release 包。'
 }
 
-Write-Host '=== [2/3] 安装 router-standard 预设 ===' -ForegroundColor Cyan
-$target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-standard'
-if (Test-Path $target) {
-  Write-Host "预设已存在：$target（如需覆盖请先手动删除）" -ForegroundColor Yellow
-} else {
-  New-Item -ItemType Directory -Force -Path (Split-Path $target) | Out-Null
-  Copy-Item -Recurse (Join-Path $root 'preset\preset') $target
+$dsh = Get-Command dsh -ErrorAction SilentlyContinue
+if (-not $dsh) {
+  throw '找不到 dsh 命令。请先安装 DSH，并将 dsh 加入 PATH。'
+}
+
+& $dsh.Source plugin --profile web add $injector 2>&1 | Out-Host
+if ($LASTEXITCODE -ne 0) {
+  throw "dsh plugin add 失败，退出代码：$LASTEXITCODE"
+}
+Write-Host '注入器已装配（重启后由 bundles 接管）' -ForegroundColor Green
+
+Write-Host '=== [2/3] 安装路由预设 ===' -ForegroundColor Cyan
+$presetRoot = Join-Path $root 'preset\preset'
+$targetRoot = Join-Path $env:USERPROFILE '.dsh\.agent-presets'
+
+foreach ($name in @('router-standard', 'router-spec')) {
+  $source = Join-Path $presetRoot $name
+  $target = Join-Path $targetRoot $name
+
+  if (-not (Test-Path (Join-Path $source 'preset.yml'))) {
+    throw "预设源目录无效：$source"
+  }
+
+  if (Test-Path $target) {
+    if (Test-Path (Join-Path $target 'preset.yml')) {
+      Write-Host "预设已存在，跳过：$target" -ForegroundColor Yellow
+      continue
+    }
+    throw "目标目录已存在但不是有效预设：$target。请检查或移走该目录后重试。"
+  }
+
+  New-Item -ItemType Directory -Force -Path $targetRoot | Out-Null
+  Copy-Item -Recurse $source $target
   Write-Host "预设已安装：$target" -ForegroundColor Green
 }
 
 Write-Host '=== [3/3] 完成 ===' -ForegroundColor Cyan
 Write-Host '1. 重启 DSH（web 服务）' -ForegroundColor Yellow
-Write-Host '2. GUI 新建会话 → 选择 Router Standard (experimental)' -ForegroundColor Yellow
+Write-Host '2. GUI 新建会话 → 选择 Router Standard / Router Spec' -ForegroundColor Yellow
 Write-Host '3. 发任务：生成任务自动 react，维护任务自动 spec，模糊任务进 weak 内路由' -ForegroundColor Yellow
 Write-Host '4. AI 自优化工具：dev_router_status / dev_router_mode / dev_mode_subagent' -ForegroundColor Yellow


### PR DESCRIPTION
## 问题

在 Windows PowerShell 5.1 中运行 `install.ps1` 时会遇到两个问题：

1. 系统执行策略可能阻止 `.ps1` 脚本运行。
2. `install.ps1` 原本使用 UTF-8 无 BOM 编码。由于脚本包含中文，Windows PowerShell 5.1 可能按系统 ANSI 代码页读取文件，进而误报：
   - 字符串缺少终止符
   - 语句块缺少右大括号

脚本本身的引号和大括号实际是完整的。

## 修改内容

- 将 `install.ps1` 保存为 UTF-8 with BOM，兼容 Windows PowerShell 5.1。
- 更新中英文 README，使用仅对单次进程生效的执行方式：

  ```powershell
  powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\install.ps1