### PR TITLE
suite: preset v0.2.0+fix(#13,#11) — install.ps1 PS5.1 fix + auto tgz download + README v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # dsh-routing-suite — 注入器 × 思维模式路由 套装
 
-一个仓库装齐「运行时手术台 + 思维模式路由预设」：先装注入器（免重启运行时管理层），
-再用它装配 router-standard 预设（任务感知思维模式路由，P1-P23 实测）。
+一个仓库装齐「运行时手术台 + 任务感知思维模式路由预设」：先装注入器（免重启运行时管理层），
+再用它装配 router-standard / router-spec 预设（任务感知思维模式路由，P1-P30 实测）。
 
 [中文](README.md) | [English](README.en.md)
 
-## 安装链（三步）
+> **v0.2.0 重要变更**：路由预设拆分为两个独立预设——
+> `router-standard`（默认，RL 接口还原：一句话人设 + shell/编辑器双工具面，边想边做）与
+> `router-spec`（深度思考优先：分类 persona + 完整提示词段，首轮长思维链是其特征）。
+> 同时修正了理论叙事（见 [preset 勘误声明](https://github.com/yjh051108/dsh-router-standard/blob/main/docs/apology.md)）。
+
+## 安装链（两步）
 
 ```powershell
 # 1. 拉套装（含两个 submodule）
@@ -16,44 +21,89 @@ cd dsh-routing-suite
 .\install.ps1
 ```
 
-或手动：
+升级已装的预设：
+
+```powershell
+.\install.ps1 -Update   # 覆盖 preset（自动备份旧版）；注入器缺失 lib 时自动从 Release 下载 tgz
+```
+
+手动安装：
 
 ```powershell
 # 步骤 1：装配注入器（官方装配，重启后由 bundles 接管）
 dsh plugin --profile web add .\injector
 
-# 步骤 2：安装 router-standard 预设
-$target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-standard'
-Copy-Item -Recurse .\preset\preset $target
+# 步骤 2：安装预设
+$dst = Join-Path $env:USERPROFILE '.dsh\.agent-presets'
+Copy-Item -Recurse .\preset\preset\router-standard $dst
+Copy-Item -Recurse .\preset\preset\router-spec      $dst
 
-# 步骤 3：重启 DSH → 新会话选择 Router Standard (experimental)
+# 步骤 3：重启 DSH → 新会话选择 Router Standard (experimental) 或 Router Spec (experimental)
 ```
+
+> 若 `injector\lib` 缺失（未构建），`install.ps1` 会自动下载官方 Release 的预构建 tgz；
+> 也可自行构建：`cd injector; bash scripts/build.sh`（需 `DSH_CHECKOUT` 指向 DSH 源码）。
 
 ## 组件
 
 | 路径 | 仓库 | 版本 | 作用 |
 |---|---|---|---|
 | `injector/` | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | [v0.3.3](https://github.com/yjh051108/dsh-super-injector/releases/tag/v0.3.3) | 运行时注入器：dev_* 工具全家桶（注入/热重载/侧挂转正/卸载/路由自愈） |
-| `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [v0.3.0](https://github.com/yjh051108/dsh-router-standard/releases/tag/v0.3.0) | 思维模式路由预设：router-standard（RL 接口还原）/ router-spec（深度思考优先）/ router-pro（Pro 测量最优） |
+| `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [v0.2.0](https://github.com/yjh051108/dsh-router-standard/releases/tag/v0.2.0) | 双预设：router-standard（RL 接口还原）/ router-spec（深度思考优先） |
 | `mode-boost/` | [dsh-mode-boost](https://github.com/yjh051108/dsh-mode-boost) | [v0.1.0](https://github.com/yjh051108/dsh-mode-boost/releases/tag/v0.1.0) | 模式提升插件：deep-persona 收敛提升 / boost 重分类引导 / 深度自适应分派（宿主平面，装配在官方 preset 之上） |
 
 > 版本号以各组件仓库的 git tag 为准（列内链接直达对应 Release）。
 
 三个组件独立演进（submodule 指向各自 main），套装聚合安装链与总览。
 
-## router-standard 预设能力（P1-P23 实测摘要）
+## 预设能力摘要
 
-- **三行为带 + weak 内路由**：spec（计划-集体）/ react（执行者）/ mixed（陷阱，回避）/ weak（模型自分类）
-- **按模型选 persona**：Pro=spec 句+few-shot（区分度 +5.0）；Flash=neutral+classify（+5.7）
-- **近距离引导**：每轮用户消息后注入固定引导（缓存 92-94% 命中），路由 96% + 收敛 100% + 反稀释
-- **单任务三锚**（persona 静态）：回顾 + 收敛 + 反跑题 —— 开放任务完成率 0% → 100%
-- **plan-mode 保留**：只替换 persona section，plan 边界不失忆
-- **AI 自优化工具**：`dev_router_status` / `dev_router_mode` / `dev_mode_subagent`
+**Router Standard (experimental)** — RL 接口还原（v0.2.0 默认）
+- 首轮 system 只有 RL 训练句 + shell/str_replace_editor 工具面，模型「想一段、做一段」
+- 实测：25 步 / 24 工具调用 / 19KB 产物 vs 旧面 101K 推理字符零行动
+- 首轮工具调用后自动展开完整 Standard 工具目录
+
+**Router Spec (experimental)** — 深度思考优先（v0.2.0 新增）
+- 分类 persona（spec 计划型 / react 执行型）+ 保留全部提示词段
+- 首轮超长思维链是特征（101K 推理 0 行动），适合需要先想透再动手的任务
+
+**两个预设共有**
+- 三行为带 + weak 内路由：spec（计划）/ react（执行）/ weak（模型自分类，就近引导）
+- 首轮路由读取 `agent/inbox/claimed`（assemble 之前必达），并过滤插件注入消息（`source.kind`）
+  ——修复了「首轮无条件落 weak」与「user-approval 消息钉死 weak」两类结构性失效（issue #13）
+- 近距离引导：每轮真实用户消息后注入固定引导（缓存友好）
+- 单任务三锚（persona 静态）：回顾 + 收敛 + 反跑题
+- AI 自优化工具：`dev_router_status` / `dev_router_mode` / `dev_mode_subagent`
+
+## 平台支持
+
+| 平台 | 状态 | 说明 |
+|---|---|---|
+| Windows（PowerShell 5.1/7+） | ✅ | install.ps1 纯 ASCII，PS 5.1 解析通过（issue #16 已修） |
+| WSL / Linux / macOS | ✅ | 预设与注入器均为跨平台 Node 代码；注入器构建需 `bash scripts/build.sh` + `DSH_CHECKOUT`，或直接用 Release tgz |
+
+## FAQ
+
+**Q：安装后 DSH 启动报 `Cannot find module ... lib/index.js`？**
+A：注入器未构建/未下载。用 `install.ps1` 重装（自动下载 Release tgz），或先 `cd injector; bash scripts/build.sh` 再 `dsh plugin --profile web add .\injector`。
+
+**Q：Web UI 设置页「插件」空白？**
+A：属注入器侧的 UI 注册问题，v0.3.x 已修复（`slots.register(options, component)` 正确写法）。升级注入器即可。
+
+**Q：能正常使用 skill 和插件吗？**
+A：可以。预设只替换首轮 persona 段与工具面，skills/其他插件的注册在 host 平面不受影响；首轮工具调用后完整目录即恢复。
+
+**Q：支持其他 DeepSeek API 厂商（火山、千帆、Opencode 等）吗？**
+A：路由逻辑与模型通道无关——任何 `agent.options.provider/model` 都走同一路由；persona 按模型族（Pro/Flash）区分，其余由你的 provider 配置决定。
+
+**Q：有使用教程吗？**
+A：装好后新建会话选择对应预设即可；`dev_router_status` 可查看当前路由状态。深度文档见 [preset/docs](https://github.com/yjh051108/dsh-router-standard/tree/main/docs)。
 
 ## 文档
 
 - 注入器引导（规范铁律 10 条）：`injector/README.md`
-- 路由预设论文与实验：`preset/docs/paper.md` + `preset/docs/experiments.md`（P1-P23）
+- 路由预设论文与实验：`preset/docs/paper.md` + `preset/docs/experiments.md`（P1-P30）
+- 理论勘误：`preset/docs/apology.md`
 
 ## 许可证
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,29 +1,89 @@
-# dsh-routing-suite 一键安装（Windows PowerShell）
-# 步骤：1) 装配注入器  2) 安装 router-standard 预设  3) 提示重启
+# dsh-routing-suite one-click installer (Windows PowerShell / pwsh).
+# Steps: 1) attach the injector  2) install router-standard + router-spec presets
+#        3) hint to restart DSH.
+#
+# NOTE: this file is pure ASCII on purpose. PowerShell 5.1 reads BOM-less
+# scripts as ANSI/GBK, and non-ASCII bytes previously broke the parser
+# ("string missing terminator" on line 29) - see issue #16.
+#
+# Usage:
+#   .\install.ps1            install (skips existing presets)
+#   .\install.ps1 -Update    force-overwrite presets (upgrade path)
+#   .\install.ps1 -SkipInjector   preset-only install
+[CmdletBinding()]
+param(
+  [switch]$Update,
+  [switch]$SkipInjector
+)
 $ErrorActionPreference = 'Stop'
 $root = Split-Path -Parent $MyInvocation.MyCommand.Path
 
-Write-Host '=== [1/3] 装配注入器 ===' -ForegroundColor Cyan
-$injector = Join-Path $root 'injector'
-if (-not (Test-Path (Join-Path $injector 'lib\index.js'))) {
-  Write-Host 'injector/lib 缺失——先构建：cd injector; bash scripts/build.sh（需 DSH_CHECKOUT）或从 Release 下载 tgz' -ForegroundColor Yellow
+Write-Host '=== [1/3] injector ===' -ForegroundColor Cyan
+if (-not $SkipInjector) {
+  $injector = Join-Path $root 'injector'
+  if (Test-Path (Join-Path $injector 'lib\index.js')) {
+    & dsh plugin --profile web add $injector 2>&1 | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "dsh plugin add failed (exit $LASTEXITCODE)" }
+    Write-Host 'injector attached (bundles take over after restart)' -ForegroundColor Green
+  } else {
+    Write-Host 'injector/lib missing - downloading prebuilt tgz from GitHub Releases...' -ForegroundColor Yellow
+    try {
+      $api = Invoke-RestMethod -Uri 'https://api.github.com/repos/yjh051108/dsh-super-injector/releases/latest' -Headers @{ 'User-Agent' = 'dsh-routing-suite-installer' }
+      $asset = $api.assets | Where-Object { $_.name -like '*.tgz' } | Select-Object -First 1
+      if (-not $asset) { throw 'no tgz asset in latest release' }
+      $dl = Join-Path $env:TEMP 'dsh-injector-download'
+      if (Test-Path $dl) { Remove-Item -Recurse -Force $dl }
+      New-Item -ItemType Directory -Force $dl | Out-Null
+      $tgz = Join-Path $dl $asset.name
+      Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tgz
+      if (Get-Command tar -ErrorAction SilentlyContinue) {
+        tar -xzf $tgz -C $dl
+        $pkg = Get-ChildItem $dl -Directory | Where-Object { $_.Name -eq 'package' } | Select-Object -First 1
+        if (-not $pkg) { $pkg = Get-ChildItem $dl -Directory | Select-Object -First 1 }
+        if (-not $pkg) { throw 'tgz extraction produced no package dir' }
+        if (-not (Test-Path (Join-Path $pkg.FullName 'lib\index.js'))) { throw 'extracted package has no lib/index.js' }
+        & dsh plugin --profile web add $pkg.FullName 2>&1 | Out-Host
+        if ($LASTEXITCODE -ne 0) { throw "dsh plugin add failed (exit $LASTEXITCODE)" }
+        Write-Host "injector v$($api.tag_name) attached from release" -ForegroundColor Green
+      } else {
+        throw 'tar.exe not found - build injector locally (cd injector; bash scripts/build.sh) or extract the tgz manually'
+      }
+    } catch {
+      Write-Host "auto-download failed: $($_.Exception.Message)" -ForegroundColor Red
+      Write-Host 'Fallback: build injector first - cd injector; bash scripts/build.sh (needs DSH_CHECKOUT), then re-run this script.' -ForegroundColor Yellow
+    }
+  }
 } else {
-  & dsh plugin --profile web add $injector 2>&1 | Out-Host
-  Write-Host '注入器已装配（重启后由 bundles 接管）' -ForegroundColor Green
+  Write-Host 'injector skipped (-SkipInjector)' -ForegroundColor DarkGray
 }
 
-Write-Host '=== [2/3] 安装 router-standard 预设 ===' -ForegroundColor Cyan
-$target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-standard'
-if (Test-Path $target) {
-  Write-Host "预设已存在：$target（如需覆盖请先手动删除）" -ForegroundColor Yellow
-} else {
-  New-Item -ItemType Directory -Force -Path (Split-Path $target) | Out-Null
-  Copy-Item -Recurse (Join-Path $root 'preset\preset') $target
-  Write-Host "预设已安装：$target" -ForegroundColor Green
+Write-Host '=== [2/3] router presets (v0.2.0: router-standard + router-spec) ===' -ForegroundColor Cyan
+$dst = Join-Path $env:USERPROFILE '.dsh\.agent-presets'
+New-Item -ItemType Directory -Force $dst | Out-Null
+foreach ($name in @('router-standard', 'router-spec')) {
+  $target = Join-Path $dst $name
+  $src = Join-Path $root ("preset\preset\" + $name)
+  if (-not (Test-Path (Join-Path $src 'preset.yml'))) {
+    Write-Host "missing source: $src (submodule not checked out? run: git submodule update --init --recursive)" -ForegroundColor Red
+    continue
+  }
+  if (Test-Path $target) {
+    if ($Update) {
+      $bak = "$target.bak-$(Get-Date -Format yyyyMMdd-HHmmss)"
+      Move-Item $target $bak
+      Copy-Item -Recurse $src $target
+      Write-Host "$name updated (backup: $bak)" -ForegroundColor Green
+    } else {
+      Write-Host "$name already installed at $target (use -Update to overwrite)" -ForegroundColor Yellow
+    }
+  } else {
+    Copy-Item -Recurse $src $target
+    Write-Host "$name installed at $target" -ForegroundColor Green
+  }
 }
 
-Write-Host '=== [3/3] 完成 ===' -ForegroundColor Cyan
-Write-Host '1. 重启 DSH（web 服务）' -ForegroundColor Yellow
-Write-Host '2. GUI 新建会话 → 选择 Router Standard (experimental)' -ForegroundColor Yellow
-Write-Host '3. 发任务：生成任务自动 react，维护任务自动 spec，模糊任务进 weak 内路由' -ForegroundColor Yellow
-Write-Host '4. AI 自优化工具：dev_router_status / dev_router_mode / dev_mode_subagent' -ForegroundColor Yellow
+Write-Host '=== [3/3] done ===' -ForegroundColor Cyan
+Write-Host '1. Restart DSH (web service)' -ForegroundColor Yellow
+Write-Host '2. New session -> pick "Router Standard (experimental)" or "Router Spec (experimental)"' -ForegroundColor Yellow
+Write-Host '3. Send a task: build tasks route react, fix tasks route spec, fuzzy tasks route weak' -ForegroundColor Yellow
+Write-Host '4. AI self-tuning: dev_router_status / dev_router_mode / dev_mode_subagent' -ForegroundColor Yellow


### PR DESCRIPTION
## 更新内容

1. **preset 子模块 → 25e9245**：v0.2.0 (f9667f7) + 两个崩溃级修复（见 [dsh-router-standard#17](https://github.com/yjh051108/dsh-router-standard/pull/17)）：
   - 首轮路由读 gent/inbox/claimed（assemble 前必达）+ irstUserText 经 classifyTask 后再当 mode（修复「所有任务首轮路由到 spec」回归）—— issue #13 实测修复
   - xtractText 导入补全 —— issue #11 实测修复
2. **install.ps1 重写**：纯 ASCII（PowerShell 5.1 按 GBK 误读 UTF-8 中文导致解析崩溃—— issue #16 实测根因）；新增 -Update（覆盖+自动备份）、-SkipInjector；injector 缺 lib 时自动从 Release 下载预构建 tgz（issue #1/#16 的 ERR_MODULE_NOT_FOUND 场景）
3. **README 更新**：v0.2.0 双预设说明、平台支持表（Windows PS5.1/WSL/Linux/macOS）、FAQ（对应 issues #1/#4/#7/#9/#12/#16/#18/#19）

## 本地实测

- install.ps1 通过 Windows PowerShell 5.1 真实解析（修复前第 29 行「字符串缺少终止符」）
- router-standard / router-spec 两个预设安装后首轮路由行为已实测验证（react 任务首轮 REACT_PERSONA）