### PR TITLE
fix: 修正安装脚本路径、文档版本与子模块同步 workflow

### DIFF
--- a/.github/workflows/sync-submodules.yml
+++ b/.github/workflows/sync-submodules.yml
@@ -1,0 +1,29 @@
+name: sync-submodules
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Update submodules to latest main
+        run: |
+          git submodule update --remote --init
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          if git diff --quiet; then
+            echo 'No submodule changes'
+          else
+            git add .gitmodules injector preset mode-boost
+            git commit -m 'chore: sync submodules to latest main'
+            git push
+          fi

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,12 @@
 [submodule "injector"]
 	path = injector
 	url = https://github.com/yjh051108/dsh-super-injector.git
+	branch = main
 [submodule "preset"]
 	path = preset
 	url = https://github.com/yjh051108/dsh-router-standard.git
+	branch = main
 [submodule "mode-boost"]
 	path = mode-boost
 	url = https://github.com/yjh051108/dsh-mode-boost.git
+	branch = main

--- a/README.en.md
+++ b/README.en.md
@@ -1,73 +1,48 @@
 # dsh-routing-suite — Injector × Reasoning-Mode Routing Suite
-
 One repository for the full stack: the **runtime surgery table** (dsh-super-injector,
 restart-free plugin management) plus the **reasoning-mode routing presets**
 (dsh-router-standard: task-aware reasoning-mode routing) and the **mode-boost
 plugin** (measured performance lifts on top of official presets).
-
 [中文](README.md) | English
-
 ## Install chain (three steps)
-
 ```powershell
 # 1. Clone the suite (includes three submodules)
 git clone --recurse-submodules https://github.com/yjh051108/dsh-routing-suite.git
 cd dsh-routing-suite
-
-# 2. One-shot install (injector assembly + preset copy + restart prompt)
+# 2. One-shot install (injector assembly + preset copy + optional mode-boost + restart prompt)
 .\install.ps1
 ```
-
 Or manually:
-
 ```powershell
 # Step 1: assemble the injector (official assembly; bundles take over after restart)
 dsh plugin --profile web add .\injector
-
 # Step 2: install the router presets (one or both)
 $target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-standard'
 Copy-Item -Recurse .\preset\preset\router-standard $target
-
 $target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-spec'
 Copy-Item -Recurse .\preset\preset\router-spec $target
-
-# Step 3: restart DSH → pick Router Standard / Router Spec in a new session
+# Step 3 (optional): assemble mode-boost
+dsh plugin --profile web add .\mode-boost
+# Step 4: restart DSH → pick Router Standard / Router Spec in a new session
 ```
-
 ## Components
-
 | Path | Repo | Version | Role |
 |---|---|---|---|
 | `injector/` | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | [v0.3.3](https://github.com/yjh051108/dsh-super-injector/releases/tag/v0.3.3) | Runtime injector: dev_* tool family (inject / hot-reload / staging-promote / uninject / route self-heal) |
-| `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [v0.3.0](https://github.com/yjh051108/dsh-router-standard/releases/tag/v0.3.0) | Reasoning-mode routing presets: router-standard (RL-interface restoration) / router-spec (deep-think-first) / router-pro (V4 Pro measured optimum) |
-| `mode-boost/` | [dsh-mode-boost](https://github.com/yjh051108/dsh-mode-boost) | [v0.1.0](https://github.com/yjh051108/dsh-mode-boost/releases/tag/v0.1.0) | Mode-boost plugin: deep-persona convergence lift / boost reclassification guidance / depth-adaptive dispatch (host-plane, mounts on top of official presets) |
-
+| `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [v0.2.0](https://github.com/yjh051108/dsh-router-standard/releases/tag/v0.2.0) | Reasoning-mode routing presets: router-standard (RL-interface restoration) / router-spec (deep-think-first) |
+| `mode-boost/` | [dsh-mode-boost](https://github.com/yjh051108/dsh-mode-boost) | [v0.1.0](https://github.com/yjh051108/dsh-mode-boost/releases/tag/v0.1.0) | Mode-boost plugin: deep-persona convergence lift / boost reclassification guidance / depth-adaptive dispatch (host-plane, mounts on top of official presets, optional) |
 > Versions follow each component repo's git tag (links go to the matching Release).
-
-The three components evolve independently (submodules point at each repo's
-`main`); the suite aggregates the install chain and the overview.
-
+> The suite's `main` currently locks preset at v0.2.0 (router-standard / router-spec); router-pro is not part of the suite yet.
+The three components evolve independently (submodules point at commits); the suite aggregates the install chain and the overview.
 ## router-standard preset capabilities (P1–P23 measured summary)
-
 - **Three behavior bands + weak internal routing**: spec (plan-collective) / react (doer) / mixed (trap, avoided) / weak (model self-classifies)
 - **Model-matched persona**: Pro = spec sentence + few-shot (discrimination +5.0); Flash = neutral + classify (+5.7)
 - **Near-field guidance**: fixed guidance after every real user message (cache 92–94% hit), routing 96% + convergence 100% + anti-dilution
 - **Single-task three anchors** (persona-static): recall + converge + anti-runaway — open-task completion 0% → 100%
 - **plan-mode preserved**: only the persona section is replaced; plan boundaries never lose focus
 - **AI self-optimization tools**: `dev_router_status` / `dev_router_mode` / `dev_mode_subagent`
-
-## Router Pro (v0.3.0) highlights
-
-- V4 Pro measured-optimal routing: maintenance → RL interface (anchored-standard 98/99), build → doer (Mario 10/10), no-evidence → weak (router-v2 few-shot, discrimination +2.6 n=10)
-- **Decision-closure loop** (all-branch near-field guidance): black-hole reasoning 58K→27K (2.1× curbed) with 100% action — **no budget cap**
-- Competition band [0.03, 0.455] never touched (E2 matrix: 9/12 anti-routing, peak −10.6)
-- Model split: Pro = router-v2 few-shot + decision closure; Flash = w7 + commit guidance
-
 ## Docs
-
 - Injector guide (10 rules): `injector/README.md`
-- Routing preset paper & experiments: `preset/docs/paper.md` + `preset/docs/experiments.md` (P1–P23), `preset/docs/paper-pro.md` (V4 Pro)
-
+- Routing preset paper & experiments: `preset/docs/paper.md` + `preset/docs/experiments.md` (P1–P23)
 ## License
-
 MIT. Credits: xiaobright/modeltest (V4.1b evaluation), xiaobright/dsh-anchored-standard (anchoring mechanism).

--- a/README.md
+++ b/README.md
@@ -1,60 +1,51 @@
 # dsh-routing-suite — 注入器 × 思维模式路由 套装
-
 一个仓库装齐「运行时手术台 + 思维模式路由预设」：先装注入器（免重启运行时管理层），
 再用它装配 router-standard 预设（任务感知思维模式路由，P1-P23 实测）。
-
 [中文](README.md) | [English](README.en.md)
-
 ## 安装链（三步）
-
 ```powershell
-# 1. 拉套装（含两个 submodule）
+# 1. 拉套装（含三个 submodule）
 git clone --recurse-submodules https://github.com/yjh051108/dsh-routing-suite.git
 cd dsh-routing-suite
-
-# 2. 一键安装（注入器装配 + 预设复制 + 提示重启）
+# 2. 一键安装（注入器装配 + 预设复制 + mode-boost 可选 + 提示重启）
 .\install.ps1
 ```
-
 或手动：
-
 ```powershell
 # 步骤 1：装配注入器（官方装配，重启后由 bundles 接管）
 dsh plugin --profile web add .\injector
 
-# 步骤 2：安装 router-standard 预设
+# 步骤 2：安装 router-standard 预设（注意复制的是 preset/preset/router-standard）
 $target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-standard'
-Copy-Item -Recurse .\preset\preset $target
+Copy-Item -Recurse .\preset\preset\router-standard $target
 
-# 步骤 3：重启 DSH → 新会话选择 Router Standard (experimental)
+# 步骤 2b（可选）：安装 router-spec 预设
+$target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-spec'
+Copy-Item -Recurse .\preset\preset\router-spec $target
+
+# 步骤 3（可选）：装配 mode-boost 插件
+dsh plugin --profile web add .\mode-boost
+
+# 步骤 4：重启 DSH → 新会话选择 Router Standard (experimental)
 ```
-
 ## 组件
-
 | 路径 | 仓库 | 版本 | 作用 |
 |---|---|---|---|
 | `injector/` | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | [v0.3.3](https://github.com/yjh051108/dsh-super-injector/releases/tag/v0.3.3) | 运行时注入器：dev_* 工具全家桶（注入/热重载/侧挂转正/卸载/路由自愈） |
-| `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [v0.3.0](https://github.com/yjh051108/dsh-router-standard/releases/tag/v0.3.0) | 思维模式路由预设：router-standard（RL 接口还原）/ router-spec（深度思考优先）/ router-pro（Pro 测量最优） |
-| `mode-boost/` | [dsh-mode-boost](https://github.com/yjh051108/dsh-mode-boost) | [v0.1.0](https://github.com/yjh051108/dsh-mode-boost/releases/tag/v0.1.0) | 模式提升插件：deep-persona 收敛提升 / boost 重分类引导 / 深度自适应分派（宿主平面，装配在官方 preset 之上） |
-
+| `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [v0.2.0](https://github.com/yjh051108/dsh-router-standard/releases/tag/v0.2.0) | 思维模式路由预设：router-standard（RL 接口还原）/ router-spec（深度思考优先） |
+| `mode-boost/` | [dsh-mode-boost](https://github.com/yjh051108/dsh-mode-boost) | [v0.1.0](https://github.com/yjh051108/dsh-mode-boost/releases/tag/v0.1.0) | 模式提升插件：deep-persona 收敛提升 / boost 重分类引导 / 深度自适应分派（宿主平面，装配在官方 preset 之上，可选） |
 > 版本号以各组件仓库的 git tag 为准（列内链接直达对应 Release）。
-
-三个组件独立演进（submodule 指向各自 main），套装聚合安装链与总览。
-
+> 当前套装 main 锁定的 preset 为 v0.2.0（router-standard / router-spec）；router-pro 尚未包含在套装内。
+三个组件独立演进（submodule 指向各自仓库的提交），套装聚合安装链与总览。
 ## router-standard 预设能力（P1-P23 实测摘要）
-
 - **三行为带 + weak 内路由**：spec（计划-集体）/ react（执行者）/ mixed（陷阱，回避）/ weak（模型自分类）
 - **按模型选 persona**：Pro=spec 句+few-shot（区分度 +5.0）；Flash=neutral+classify（+5.7）
 - **近距离引导**：每轮用户消息后注入固定引导（缓存 92-94% 命中），路由 96% + 收敛 100% + 反稀释
 - **单任务三锚**（persona 静态）：回顾 + 收敛 + 反跑题 —— 开放任务完成率 0% → 100%
 - **plan-mode 保留**：只替换 persona section，plan 边界不失忆
 - **AI 自优化工具**：`dev_router_status` / `dev_router_mode` / `dev_mode_subagent`
-
 ## 文档
-
 - 注入器引导（规范铁律 10 条）：`injector/README.md`
 - 路由预设论文与实验：`preset/docs/paper.md` + `preset/docs/experiments.md`（P1-P23）
-
 ## 许可证
-
 MIT。致谢：xiaobright/modeltest（V4.1b 评测）、xiaobright/dsh-anchored-standard（锚定机制）。

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,5 @@
 # dsh-routing-suite 一键安装（Windows PowerShell）
-# 步骤：1) 装配注入器  2) 安装 router-standard 预设  3) 提示重启
+# 步骤：1) 装配注入器  2) 安装 router-standard 预设  3) 装配 mode-boost（可选）  4) 提示重启
 $ErrorActionPreference = 'Stop'
 $root = Split-Path -Parent $MyInvocation.MyCommand.Path
 
@@ -18,11 +18,20 @@ if (Test-Path $target) {
   Write-Host "预设已存在：$target（如需覆盖请先手动删除）" -ForegroundColor Yellow
 } else {
   New-Item -ItemType Directory -Force -Path (Split-Path $target) | Out-Null
-  Copy-Item -Recurse (Join-Path $root 'preset\preset') $target
+  Copy-Item -Recurse (Join-Path $root 'preset\preset\router-standard') $target
   Write-Host "预设已安装：$target" -ForegroundColor Green
 }
 
-Write-Host '=== [3/3] 完成 ===' -ForegroundColor Cyan
+Write-Host '=== [3/3] 装配 mode-boost（可选） ===' -ForegroundColor Cyan
+$modeBoost = Join-Path $root 'mode-boost'
+if (-not (Test-Path (Join-Path $modeBoost 'lib\index.js'))) {
+  Write-Host 'mode-boost/lib 缺失——先构建：cd mode-boost; bash scripts/build.sh；如不需要可跳过' -ForegroundColor Yellow
+} else {
+  & dsh plugin --profile web add $modeBoost 2>&1 | Out-Host
+  Write-Host 'mode-boost 已装配（重启后由 bundles 接管）' -ForegroundColor Green
+}
+
+Write-Host '=== 完成 ===' -ForegroundColor Cyan
 Write-Host '1. 重启 DSH（web 服务）' -ForegroundColor Yellow
 Write-Host '2. GUI 新建会话 → 选择 Router Standard (experimental)' -ForegroundColor Yellow
 Write-Host '3. 发任务：生成任务自动 react，维护任务自动 spec，模糊任务进 weak 内路由' -ForegroundColor Yellow


### PR DESCRIPTION
## 问题

当前仓库存在几处配置/文档不一致，导致按 README 或 `install.ps1` 安装时无法正确工作：

1. **版本不一致**：README / Release 声称 preset 为 v0.3.0（含 router-pro），但当前 main 实际锁定的 preset 子模块是 v0.2.0（仅 router-standard / router-spec），且 `dsh-router-standard` 仓库没有 v0.3.0 tag。
2. **`install.ps1` 复制路径错误**：复制 `preset\preset` 到 `router-standard`，实际会得到 `router-standard/router-standard`、`router-standard/router-spec` 的嵌套结构，DSH 无法识别预设；应复制 `preset\preset\router-standard`。
3. **mode-boost 未纳入安装链**：组件表包含 mode-boost，但 `install.ps1` 不安装它。
4. **Release 声称存在 `sync-submodules.yml` workflow，但仓库里没有该文件**。
5. 中文 README 写“含两个 submodule”，实际 `.gitmodules` 有三个。

## 修改内容

- `install.ps1`：修正预设复制源路径；新增 mode-boost 可选装配步骤。
- `README.md` / `README.en.md`：统一为当前实际锁定的 preset v0.2.0；修正 submodule 数量与手动安装路径；标注 router-pro 尚未包含；标注 mode-boost 为可选。
- `.gitmodules`：为三个子模块补充 `branch = main`，供自动同步 workflow 使用。
- 新增 `.github/workflows/sync-submodules.yml`：定时 + 手动触发，将子模块同步到各自 main，使 Release 声明与实际仓库一致。

## 验证说明

本地环境已确认：
- `dsh-super-injector` 可正常装配（当前 v0.3.3）。
- `dsh-mode-boost` 已通过 `dev_install_package` 热装配进 web profile，重启后由 bundles 接管。
- `router-standard` 预设应复制 `preset/preset/router-standard` 下的文件到 `~/.dsh/.agent-presets/router-standard`（扁平结构），而非嵌套结构。