### PR TITLE
fix: pin .sh to LF — CRLF breaks bash on Windows (root cause of pipefail error)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must stay LF: CRLF breaks bash ("set -o pipefail" fails
+# with "invalid option name" because of the trailing \r), and Windows
+# checkouts with core.autocrlf=true would otherwise convert them.
+*.sh text eol=lf


### PR DESCRIPTION
# fix: keep `.sh` scripts LF — CRLF breaks bash `set -o pipefail` on Windows

## 问题

Windows 用户 `git clone` 本仓库后直接运行：

```powershell
PS E:\project\dsh-routing-suite\injector> bash scripts/build.sh
: invalid option namee 4: set: pipefail
```

**根因**：用户机器 `core.autocrlf=true`（Windows 常见默认）时，git 会把 `.sh` 脚本检出为 **CRLF 行尾**。bash 把 `set -euo pipefail` 读成 `set -euo pipefail\r` → `invalid option name`（行尾 `\r` 还会把终端输出弄花）。仓库本身存储的是 LF，问题 100% 出在检出侧。

实测：`mode-boost/scripts/build.sh`（无需 DSH_CHECKOUT）在 CRLF 下同样报 `line 4: set: pipefail: invalid option name`；转 LF 后立即通过。

## 修复

新增 `.gitattributes`：

```gitattributes
*.sh text eol=lf
```

`eol=lf` 使 git 无论 `core.autocrlf` 为何值都按 LF 检出 `.sh` 文件。子模块（injector/mode-boost）各自独立成仓，根目录的 `.gitattributes` 管不到它们，所以需要**每个仓库各放一份**（本 PR 只含本仓库的；其余见关联 PR）。

## 关联

- 本仓库 install.ps1 的预设复制 bug 已被 #15 / #24 / #25 覆盖，本 PR 不重复改动
- 实测环境：Windows + Git Bash（WSL bash 无 node，脚本需 Git Bash 执行）
