### PR TITLE
fix(install): copy presets flat so DSH discovery finds them

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -13,13 +13,21 @@ if (-not (Test-Path (Join-Path $injector 'lib\index.js'))) {
 }
 
 Write-Host '=== [2/3] 安装 router-standard 预设 ===' -ForegroundColor Cyan
-$target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-standard'
-if (Test-Path $target) {
-  Write-Host "预设已存在：$target（如需覆盖请先手动删除）" -ForegroundColor Yellow
-} else {
-  New-Item -ItemType Directory -Force -Path (Split-Path $target) | Out-Null
-  Copy-Item -Recurse (Join-Path $root 'preset\preset') $target
-  Write-Host "预设已安装：$target" -ForegroundColor Green
+$presetRoot = Join-Path $env:USERPROFILE '.dsh\.agent-presets'
+$installed = @()
+foreach ($name in @('router-standard', 'router-spec')) {
+  $target = Join-Path $presetRoot $name
+  if (Test-Path $target) {
+    Write-Host "预设已存在：$target（如需覆盖请先手动删除）" -ForegroundColor Yellow
+  } else {
+    New-Item -ItemType Directory -Force -Path $presetRoot | Out-Null
+    Copy-Item -Recurse (Join-Path $root "preset\preset\$name") $target
+    Write-Host "预设已安装：$target" -ForegroundColor Green
+    $installed += $name
+  }
+}
+if ($installed.Count -eq 0) {
+  Write-Host '两个预设均已存在，跳过复制' -ForegroundColor Yellow
 }
 
 Write-Host '=== [3/3] 完成 ===' -ForegroundColor Cyan


### PR DESCRIPTION
## 问题

`install.ps1` 执行 `Copy-Item -Recurse .\preset\preset $target`，把 `preset/preset`
**整体**复制成了 `~/.dsh/.agent-presets/router-standard`，产生嵌套结构：
~/.dsh/.agent-presets/router-standard/ ├── router-spec/ ← 真正的预设（有 agent.cordis.yml），藏在子层 └── router-standard/ ← 同上

复制

DSH 的预设发现（`@deepseek-ai/dsh-agent-presets` 的 `scanRoot`）是**非递归单层扫描**：
`~/.dsh/.agent-presets/` 下每个目录 = 一个预设，目录内必须直接有 `agent.cordis.yml`。
嵌套后 `router-standard` 壳目录缺 `agent.cordis.yml` → 被判 broken → GUI 模式列表过滤掉，
两个真实预设完全不可见。**重启后新建会话看不到 Router Standard (experimental)。**

## 修复

逐预设复制到 `~/.dsh/.agent-presets/` 顶层（与 preset 仓库 README 的 Usage 一致）：

- `preset/preset/router-standard` → `~/.dsh/.agent-presets/router-standard`
- `preset/preset/router-spec` → `~/.dsh/.agent-presets/router-spec`

## 验证

用 DSH 官方发现逻辑 `discoverPresets` 验证：
{"id":"router-spec","name":"Router Spec (experimental)", "broken":null} {"id":"router-standard","name":"Router Standard (experimental)", "broken":null}

复制

配套修复：dsh-router-standard 仓库的 `preset.yml` YAML 语法（description 含冒号+空格导致 js-yaml 解析失败、显示名为空），见关联 PR。