### PR TITLE
chore: sync preset to dsh-router-standard main and fix install paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "injector"]
 	path = injector
 	url = https://github.com/yjh051108/dsh-super-injector.git
+	branch = main
 [submodule "preset"]
 	path = preset
 	url = https://github.com/yjh051108/dsh-router-standard.git
+	branch = main

--- a/README.en.md
+++ b/README.en.md
@@ -1,8 +1,8 @@
 # dsh-routing-suite — Injector × Reasoning-Mode Routing Suite
 
 One repository for the full stack: the **runtime surgery table** (dsh-super-injector,
-restart-free plugin management) plus the **reasoning-mode routing presets**
-(dsh-router-standard: task-aware reasoning-mode routing).
+restart-free plugin management) plus the **official routing presets from
+dsh-router-standard** (router-standard / router-spec / router-react).
 
 [中文](README.md) | English
 
@@ -24,31 +24,40 @@ Or manually:
 dsh plugin --profile web add .\injector
 # If dsh is not on PATH (npx @deepseek-ai/dsh web): npx '@deepseek-ai/dsh' plugin --profile web add .\injector
 
-# Step 2: install the router presets (one or both; DSH scans one level only,
+# Step 2: install the router presets (DSH scans one level only,
 # so each preset directory must sit FLAT under .agent-presets)
+# The preset submodule layout is preset/preset/<preset-name>.
 $target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-standard'
-Copy-Item -Recurse .\preset\router-standard $target
+Copy-Item -Recurse .\preset\preset\router-standard $target
 
 $target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-spec'
-Copy-Item -Recurse .\preset\router-spec $target
+Copy-Item -Recurse .\preset\preset\router-spec $target
 
-# Step 3: restart DSH → pick Router Standard / Router Spec in a new session
+$target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-react'
+Copy-Item -Recurse .\preset\preset\router-react $target
+
+# Step 3: restart DSH → pick Router Standard / Router Spec / Router React
 ```
 
 > Do NOT copy the `preset` directory as a whole — the extra nesting hides the
-> presets from DSH discovery.
+> presets from DSH discovery. `install.ps1` auto-detects both `preset/preset/`
+> and the legacy `preset/` layout.
 
 ## Components
 
 | Path | Repo | Version | Role |
 |---|---|---|---|
 | `injector/` | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | [v0.3.3](https://github.com/yjh051108/dsh-super-injector/releases/tag/v0.3.3) | Runtime injector: dev_* tool family (inject / hot-reload / staging-promote / uninject / route self-heal); git installs build automatically (prepare hook) |
-| `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [v0.3.0](https://github.com/yjh051108/dsh-router-standard/releases/tag/v0.3.0) | Reasoning-mode routing presets: router-standard (classified persona + full sections) / router-spec (deep-think-first). router-pro is planned but NOT part of v0.3.0 |
+| `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [latest main](https://github.com/yjh051108/dsh-router-standard/tree/main) | Routing presets: router-standard (progressive disclosure + task routing) / router-spec (deep-think-first) / router-react (RL-interface restoration) |
 
-> Versions follow each component repo's git tag (links go to the matching Release).
+> The submodule pointer is the current version; component repos may also publish Release tags.
 
 The two components evolve independently (submodules point at each repo's
 `main`); the suite aggregates the install chain and the overview.
+
+> The `preset/` submodule is now synced to the dsh-router-standard `main`
+> research line. The P1–P23 and v0.3.0 sections below remain as the historical
+> routing-line summary.
 
 ## router-standard preset capabilities (P1–P23 measured summary)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dsh-routing-suite — 注入器 × 思维模式路由 套装
 
 一个仓库装齐「运行时手术台 + 思维模式路由预设」：先装注入器（免重启运行时管理层），
-再用它装配 router-standard 预设（任务感知思维模式路由，P1-P23 实测）。
+再用它装配 dsh-router-standard 官方预设（router-standard / router-spec / router-react）。
 
 [中文](README.md) | [English](README.en.md)
 
@@ -24,27 +24,35 @@ dsh plugin --profile web add .\injector
 # dsh 不在 PATH 时：npx '@deepseek-ai/dsh' plugin --profile web add .\injector
 
 # 步骤 2：安装 router 预设（每个预设目录平铺复制到 .agent-presets 下，DSH 只扫一级子目录）
+# preset submodule 的官方布局是 preset/preset/<preset-name>。
 $target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-standard'
-Copy-Item -Recurse .\preset\router-standard $target
+Copy-Item -Recurse .\preset\preset\router-standard $target
 
 $target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-spec'
-Copy-Item -Recurse .\preset\router-spec $target
+Copy-Item -Recurse .\preset\preset\router-spec $target
 
-# 步骤 3：重启 DSH → 新会话选择 Router Standard / Router Spec (experimental)
+$target = Join-Path $env:USERPROFILE '.dsh\.agent-presets\router-react'
+Copy-Item -Recurse .\preset\preset\router-react $target
+
+# 步骤 3：重启 DSH → 新会话选择 Router Standard / Router Spec / Router React
 ```
 
-> 注意：不要复制 `preset` 整目录（会多套一层，DSH 发现不了预设）。
+> 注意：不要复制 `preset` 整目录（会多套一层，DSH 发现不了预设）；install.ps1 会自动识别
+> `preset/preset/` 与旧版 `preset/` 两种布局。
 
 ## 组件
 
 | 路径 | 仓库 | 版本 | 作用 |
 |---|---|---|---|
 | `injector/` | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | [v0.3.3](https://github.com/yjh051108/dsh-super-injector/releases/tag/v0.3.3) | 运行时注入器：dev_* 工具全家桶（注入/热重载/侧挂转正/卸载/路由自愈）；`github:` 装配由 prepare 钩子自动构建 |
-| `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [v0.3.0](https://github.com/yjh051108/dsh-router-standard/releases/tag/v0.3.0) | 思维模式路由预设：router-standard（分类 persona + 完整 sections）/ router-spec（深度思考优先）。router-pro 为规划中（planned），未随 v0.3.0 发布 |
+| `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [latest main](https://github.com/yjh051108/dsh-router-standard/tree/main) | 路由预设：router-standard（渐进披露 + 任务路由）/ router-spec（深度思考优先）/ router-react（RL 接口还原） |
 
-> 版本号以各组件仓库的 git tag 为准（列内链接直达对应 Release）。
+> submodule 指针即当前版本；有 Release tag 时组件仓库会另行发布。
 
 两个组件独立演进（submodule 指向各自 main），套装聚合安装链与总览。
+
+> 当前 preset submodule 已同步到 dsh-router-standard 的 main 研发线；下方 P1-P23 与
+> v0.3.0 变更保留为历史路由线摘要。
 
 ## router-standard 预设能力（P1-P23 实测摘要）
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,5 @@
-# dsh-routing-suite 一键安装（Windows PowerShell）
-# 步骤：1) 装配注入器  2) 安装 router-standard / router-spec 预设  3) 提示重启
+﻿# dsh-routing-suite 一键安装（Windows PowerShell）
+# 步骤：1) 装配注入器  2) 安装 preset 官方路由预设  3) 提示重启
 $ErrorActionPreference = 'Stop'
 $root = Split-Path -Parent $MyInvocation.MyCommand.Path
 
@@ -37,8 +37,23 @@ if (Test-Path (Join-Path $injector 'lib\index.js')) {
 }
 
 Write-Host '=== [2/3] 安装 router presets ===' -ForegroundColor Cyan
-$presetRoot = Join-Path $root 'preset'
-$presets = @('router-standard', 'router-spec')
+# dsh-router-standard 的官方布局是 preset/preset/...；兼容旧版根目录布局。
+$presetRoot = Join-Path $root 'preset\preset'
+if (-not (Test-Path (Join-Path $presetRoot 'router-standard'))) {
+  $presetRoot = Join-Path $root 'preset'
+}
+if (-not (Test-Path $presetRoot)) {
+  Write-Host "FAIL: 找不到预设源码目录：$presetRoot" -ForegroundColor Red
+  exit 1
+}
+$presets = @(Get-ChildItem $presetRoot -Directory |
+  Where-Object { Test-Path (Join-Path $_.FullName 'agent.cordis.yml') } |
+  Select-Object -ExpandProperty Name |
+  Sort-Object)
+if ($presets.Count -eq 0) {
+  Write-Host "FAIL: 预设目录下没有含 agent.cordis.yml 的预设：$presetRoot" -ForegroundColor Red
+  exit 1
+}
 foreach ($name in $presets) {
   $target = Join-Path $env:USERPROFILE (Join-Path '.dsh\.agent-presets' $name)
   if (Test-Path $target) {
@@ -51,7 +66,7 @@ foreach ($name in $presets) {
   Write-Host "预设已安装：$target" -ForegroundColor Green
 }
 
-# 自检：两个预设一级目录必须直接含 agent.cordis.yml（防嵌套层级错误）
+# 自检：所有已安装预设的一级目录必须直接含 agent.cordis.yml（防嵌套层级错误）
 Write-Host '=== 自检预设布局 ===' -ForegroundColor Cyan
 foreach ($name in $presets) {
   $check = Join-Path $env:USERPROFILE (Join-Path '.dsh\.agent-presets' (Join-Path $name 'agent.cordis.yml'))
@@ -64,6 +79,6 @@ foreach ($name in $presets) {
 
 Write-Host '=== [3/3] 完成 ===' -ForegroundColor Cyan
 Write-Host '1. 重启 DSH（web 服务）' -ForegroundColor Yellow
-Write-Host '2. GUI 新建会话 → 选择 Router Standard / Router Spec (experimental)' -ForegroundColor Yellow
+Write-Host '2. GUI 新建会话 → 选择 Router Standard / Router Spec / Router React' -ForegroundColor Yellow
 Write-Host '3. 发任务：生成任务自动 react，维护任务自动 spec，模糊任务进 weak 内路由' -ForegroundColor Yellow
 Write-Host '4. AI 自优化工具：dev_router_status / dev_router_mode / dev_mode_subagent' -ForegroundColor Yellow

--- a/scripts/install-injector.ps1
+++ b/scripts/install-injector.ps1
@@ -1,4 +1,4 @@
-# install-injector.ps1 — dsh-super-injector 一次性安装脚本（装完即生效，无需手动重启）
+﻿# install-injector.ps1 — dsh-super-injector 一次性安装脚本（装完即生效，无需手动重启）
 #
 # 用法：
 #   .\install-injector.ps1                     # 装配 + 自动重启 DSH（默认）


### PR DESCRIPTION
Sync the preset submodule to dsh-router-standard latest main (00c81b1), fix the install source path to the official preset/preset layout, add router-react to the suite install, add UTF-8 BOM for Windows PowerShell 5.1, and declare branch=main for both submodules.