### PR TITLE
fix(preset): register bash on POSIX

### DIFF
--- a/preset/router-standard/agent.cordis.yml
+++ b/preset/router-standard/agent.cordis.yml
@@ -87,6 +87,10 @@
       name: '@deepseek-ai/dsh-tool-bash'
       disabled: !!js process.platform !== 'win32'
 
+- id: tool-bash
+  name: '@deepseek-ai/dsh-tool-bash'
+  disabled: !!js process.platform === 'win32'
+
 - id: tool-pwsh
   name: '@deepseek-ai/dsh-tool-pwsh'
   disabled: !!js process.platform !== 'win32'

--- a/preset/router.integration.test.mjs
+++ b/preset/router.integration.test.mjs
@@ -412,6 +412,11 @@ test('router visibility tools are registered', () => {
   assert.ok(!names.includes('dev_router_mode'), 'v1.20: dev_router_mode retired (no preset-internal routing)')
 })
 
+test('POSIX composition registers the model-facing bash tool', () => {
+  const config = readFileSync(new URL('./router-standard/agent.cordis.yml', import.meta.url), 'utf8')
+  assert.match(config, /^- id: tool-bash\n  name: '@deepseek-ai\/dsh-tool-bash'\n  disabled: !!js process\.platform === 'win32'$/m)
+})
+
 // ── v0.9 self-routed phases ─────────────────────────────────────────────────
 
 function tmpStageFile() {


### PR DESCRIPTION
## Summary

- Fixes: On macOS and Linux, router-standard reaches verification and reports bash as callable, but the request tool schema omits bash and direct calls fail with UNKNOWN_TOOL.
- Root cause: agent.cordis.yml registers @deepseek-ai/dsh-tool-bash only inside a Windows-only private shell group. The web host supplies the POSIX shell service but disables its model-facing shell tools, so the agent preset must register a top-level POSIX tool-bash consumer.
- Fixes #63.

## Regression evidence

- Before: `cd preset && node --test --test-name-pattern 'POSIX composition registers the model-facing bash tool' router.integration.test.mjs` exited `1`

- After: `cd preset && node --test --test-name-pattern 'POSIX composition registers the model-facing bash tool' router.integration.test.mjs` exited `0`

## Verification

- `cd preset && node router-standard/router-bootstrap-v34.selftest.mjs`
- `cd preset && npm pack --dry-run`
- `git diff --check`

The full `cd preset && npm test` run has the same pre-existing failure on the base and patched trees: `v1.19: completion signals drive the phase ladder; tool names do not` reports stage `2` instead of `1`. The focused regression and repository selftest pass after this patch.

## Scope

- 2 files changed, +9 / -0 lines
