### PR TITLE
fix(injector): isHealthyLink 误删真实包目录 + 设置页 React 渲染契约

### DIFF
--- a/injector/src/client/index.ts
+++ b/injector/src/client/index.ts
@@ -4,8 +4,15 @@
  *   - 直接注入：目录已是插件包（package.json + lib/）→ 立即注入
  *   - 内化：任意文件夹 → 新建 agent 会话 → AI 把内容变成插件
  * 通信：同源 fetch → host webServer API（/super-injector/api）
+ *
+ * ⚠️ 渲染契约（2026-08 修复）：宿主 ui-settings 的 `settings.section` 槽
+ * 期望 React 渲染函数（与 dsh-market 同款：`register(descriptor, () =>
+ * createElement(...))`）。旧实现把 component 写成"返回带 render() 方法的
+ * 对象"，在宿主渲染时抛 React #130（slot entry crashed），页面空白。
+ * 同时把与官方「插件」页重名的 label 改为「插件管理」。
  */
 import type { SlotsService } from '@deepseek-ai/dsh-client-ui-slots'
+import { createElement, useEffect, useRef } from 'react'
 
 type ClientContext = {
   slots: SlotsService
@@ -51,116 +58,124 @@ function fetchJson(path: string, init?: RequestInit): Promise<any> {
   }).then((r) => r.json())
 }
 
+/** 页面本体：DOM 构建逻辑与旧版一致，仅宿主槽渲染改为 React 容器。 */
+function InjectorPage(): any {
+  const hostRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const root = hostRef.current
+    if (!root) return
+
+    const style = document.createElement('style')
+    style.textContent = styles
+
+    const page = el('div', 'spi-page')
+    const h = el('h3', undefined, '插件管理（dsh-super-injector）')
+    const stats = el('p', 'spi-stats')
+    page.append(style, h, stats)
+
+    // ── 添加区 ──
+    const add = el('div', 'spi-add')
+    add.textContent = '拖入文件夹，或输入路径——「内化」= 新建会话让 AI 把内容变成插件；「注入」= 目录已是插件包直接注入'
+    const row = el('div', 'spi-row')
+    const input = el('input', 'spi-input') as HTMLInputElement
+    input.placeholder = 'D:/path/to/folder'
+    const btnIngest = el('button', 'spi-btn', '内化（AI 造插件）')
+    const btnInject = el('button', 'spi-btn ghost', '直接注入')
+    row.append(input, btnIngest, btnInject)
+    add.append(row)
+    page.append(add)
+
+    // 拖放（浏览器拿不到绝对路径——提示用输入框/选择器）
+    add.addEventListener('dragover', (e) => { e.preventDefault(); add.classList.add('drag') })
+    add.addEventListener('dragleave', () => add.classList.remove('drag'))
+    add.addEventListener('drop', (e) => {
+      e.preventDefault()
+      add.classList.remove('drag')
+      input.placeholder = '浏览器无法读取拖入文件夹的绝对路径——请粘贴路径或使用选择器'
+    })
+
+    // ── 列表 ──
+    const list = el('ul', 'spi-list')
+    page.append(list)
+
+    const msg = el('div', 'spi-msg')
+    msg.style.display = 'none'
+    page.append(msg)
+
+    const say = (text: string, isErr = false): void => {
+      msg.textContent = text
+      msg.style.display = text ? 'block' : 'none'
+      msg.style.borderColor = isErr ? '#d33' : 'var(--theme-border,#333)'
+    }
+
+    const refresh = (): void => {
+      fetchJson('/list')
+        .then((d) => {
+          if (!d?.ok) return say(JSON.stringify(d), true)
+          const { entries, stats: s } = d
+          stats.textContent = `inject ${s?.inject?.ok ?? 0}✓/${s?.inject?.fail ?? 0}✗ · reload ${s?.reload?.ok ?? 0}✓ · uninject ${s?.uninject?.ok ?? 0}✓/${s?.uninject?.fail ?? 0}✗ · 共 ${entries.length} 个注入插件`
+          list.textContent = ''
+          if (!entries.length) {
+            list.append(el('li', 'spi-item', '（暂无注入插件——拖入文件夹或输入路径开始）'))
+            return
+          }
+          for (const e of entries) {
+            const li = el('li', 'spi-item')
+            const name = el('span', 'name', String(e.name))
+            const dir = el('span', 'dir', String(e.dir))
+            const st = el('span', 'st ' + (e.active ? 'on' : 'off'), e.active ? '运行中' : '未激活')
+            const btn = el('button', 'spi-btn danger', '卸载')
+            btn.addEventListener('click', () => {
+              btn.disabled = true
+              btn.textContent = '卸载中…'
+              fetchJson('/uninstall', { method: 'POST', body: JSON.stringify({ match: e.name }) })
+                .then((r) => { say(r?.result ?? JSON.stringify(r), !r?.ok) })
+                .catch((err) => say('卸载请求失败: ' + err, true))
+                .finally(() => { btn.disabled = false; btn.textContent = '卸载'; setTimeout(refresh, 600) })
+            })
+            li.append(name, dir, st, btn)
+            list.append(li)
+          }
+        })
+        .catch((err) => say('加载失败: ' + err, true))
+    }
+
+    const doAction = (path: string, label: string): void => {
+      const dir = input.value.trim()
+      if (!dir) { say('请先输入文件夹路径', true); return }
+      btnIngest.disabled = btnInject.disabled = true
+      btnIngest.textContent = btnInject.textContent = '处理中…'
+      say('')
+      fetchJson(path, { method: 'POST', body: JSON.stringify({ dir, title: label }) })
+        .then((r) => { say(r?.result ?? JSON.stringify(r), !r?.ok); if (r?.ok) setTimeout(refresh, 1200) })
+        .catch((err) => say('请求失败: ' + err, true))
+        .finally(() => {
+          btnIngest.disabled = btnInject.disabled = false
+          btnIngest.textContent = '内化（AI 造插件）'
+          btnInject.textContent = '直接注入'
+        })
+    }
+    btnIngest.addEventListener('click', () => doAction('/ingest', '内化插件'))
+    btnInject.addEventListener('click', () => doAction('/inject', '直接注入'))
+
+    root.append(page)
+    refresh()
+    // 60s 轮询刷新（内化会话建好后自动出现）
+    const timer = window.setInterval(refresh, 60000)
+    return () => window.clearInterval(timer)
+  }, [])
+
+  return createElement('div', { ref: hostRef })
+}
+
 export function apply(ctx: ClientContext): void {
   ctx.effect(() => ctx.slots.inject('settings.section', () =>
     ctx.slots.register({
       name: 'settings.section',
       id: 'super-injector-plugins',
       order: 50,
-      label: () => '插件',
-      component: () => ({
-        render() {
-          const style = document.createElement('style')
-          style.textContent = styles
-
-          const page = el('div', 'spi-page')
-          const h = el('h3', undefined, '插件管理（dsh-super-injector）')
-          const stats = el('p', 'spi-stats')
-          page.append(style, h, stats)
-
-          // ── 添加区 ──
-          const add = el('div', 'spi-add')
-          add.textContent = '拖入文件夹，或输入路径——「内化」= 新建会话让 AI 把内容变成插件；「注入」= 目录已是插件包直接注入'
-          const row = el('div', 'spi-row')
-          const input = el('input', 'spi-input') as HTMLInputElement
-          input.placeholder = 'D:/path/to/folder'
-          const btnIngest = el('button', 'spi-btn', '内化（AI 造插件）')
-          const btnInject = el('button', 'spi-btn ghost', '直接注入')
-          row.append(input, btnIngest, btnInject)
-          add.append(row)
-          page.append(add)
-
-          // 拖放（浏览器拿不到绝对路径——提示用输入框/选择器）
-          add.addEventListener('dragover', (e) => { e.preventDefault(); add.classList.add('drag') })
-          add.addEventListener('dragleave', () => add.classList.remove('drag'))
-          add.addEventListener('drop', (e) => {
-            e.preventDefault()
-            add.classList.remove('drag')
-            input.placeholder = '浏览器无法读取拖入文件夹的绝对路径——请粘贴路径或使用选择器'
-          })
-
-          // ── 列表 ──
-          const list = el('ul', 'spi-list')
-          page.append(list)
-
-          const msg = el('div', 'spi-msg')
-          msg.style.display = 'none'
-          page.append(msg)
-
-          const say = (text: string, isErr = false): void => {
-            msg.textContent = text
-            msg.style.display = text ? 'block' : 'none'
-            msg.style.borderColor = isErr ? '#d33' : 'var(--theme-border,#333)'
-          }
-
-          const refresh = (): void => {
-            fetchJson('/list')
-              .then((d) => {
-                if (!d?.ok) return say(JSON.stringify(d), true)
-                const { entries, stats: s } = d
-                stats.textContent = `inject ${s?.inject?.ok ?? 0}✓/${s?.inject?.fail ?? 0}✗ · reload ${s?.reload?.ok ?? 0}✓ · uninject ${s?.uninject?.ok ?? 0}✓/${s?.uninject?.fail ?? 0}✗ · 共 ${entries.length} 个注入插件`
-                list.textContent = ''
-                if (!entries.length) {
-                  list.append(el('li', 'spi-item', '（暂无注入插件——拖入文件夹或输入路径开始）'))
-                  return
-                }
-                for (const e of entries) {
-                  const li = el('li', 'spi-item')
-                  const name = el('span', 'name', String(e.name))
-                  const dir = el('span', 'dir', String(e.dir))
-                  const st = el('span', 'st ' + (e.active ? 'on' : 'off'), e.active ? '运行中' : '未激活')
-                  const btn = el('button', 'spi-btn danger', '卸载')
-                  btn.addEventListener('click', () => {
-                    btn.disabled = true
-                    btn.textContent = '卸载中…'
-                    fetchJson('/uninstall', { method: 'POST', body: JSON.stringify({ match: e.name }) })
-                      .then((r) => { say(r?.result ?? JSON.stringify(r), !r?.ok) })
-                      .catch((err) => say('卸载请求失败: ' + err, true))
-                      .finally(() => { btn.disabled = false; btn.textContent = '卸载'; setTimeout(refresh, 600) })
-                  })
-                  li.append(name, dir, st, btn)
-                  list.append(li)
-                }
-              })
-              .catch((err) => say('加载失败: ' + err, true))
-          }
-
-          const doAction = (path: string, label: string): void => {
-            const dir = input.value.trim()
-            if (!dir) { say('请先输入文件夹路径', true); return }
-            btnIngest.disabled = btnInject.disabled = true
-            btnIngest.textContent = btnInject.textContent = '处理中…'
-            say('')
-            fetchJson(path, { method: 'POST', body: JSON.stringify({ dir, title: label }) })
-              .then((r) => { say(r?.result ?? JSON.stringify(r), !r?.ok); if (r?.ok) setTimeout(refresh, 1200) })
-              .catch((err) => say('请求失败: ' + err, true))
-              .finally(() => {
-                btnIngest.disabled = btnInject.disabled = false
-                btnIngest.textContent = '内化（AI 造插件）'
-                btnInject.textContent = '直接注入'
-              })
-          }
-          btnIngest.addEventListener('click', () => doAction('/ingest', '内化插件'))
-          btnInject.addEventListener('click', () => doAction('/inject', '直接注入'))
-
-          refresh()
-          // 60s 轮询刷新（内化会话建好后自动出现）
-          const timer = window.setInterval(refresh, 60000)
-          return {
-            dispose: () => window.clearInterval(timer),
-          }
-        },
-      }),
-    }),
+      label: () => '插件管理',
+    }, () => createElement(InjectorPage)),
   ), 'super-injector: settings page')
 }

--- a/injector/src/index.ts
+++ b/injector/src/index.ts
@@ -2061,10 +2061,14 @@ export function apply(ctx: AppContext, config: Config): void {
     return 'OK: 卸载完成\n- ' + steps.join('\n- ')
   }
 
-  /** junction 健康检查：能读目录 = 目标可达（Windows 断电后悬空 junction 的 lstat 仍是链接但读目录抛错）。 */
+  /** junction 健康检查：能读目录 = 目标可达（Windows 断电后悬空 junction 的 lstat 仍是链接但读目录抛错）。
+   *  ⚠️ 真实（非链接）目录/文件视为健康——它们是 profile 包管理器（pnpm hoisted 布局）管理的
+   *  安装实体，绝不能被当成"不健康链接"删除重建（2026-08 事故：dsh-better-sidebar 经
+   *  pnpm 装进 profile 后 dev_inject_plugin 把整个包目录 rmSync 掉换成了自指 junction）。 */
   function isHealthyLink(p: string): boolean {
     try {
-      if (!lstatSync(p).isSymbolicLink()) return false
+      const st = lstatSync(p)
+      if (!st.isSymbolicLink()) return true
       readdirSync(p)
       return true
     } catch {


### PR DESCRIPTION
## 背景

Windows + dsh web 实际使用中发现的两个 bug，已在本地实测修复并验证（`node scripts/prepare.mjs` 重建后装配运行）。

## Fix 1：`isHealthyLink` 把真实目录当"坏链接"，`dev_inject_plugin` 会误删正常安装的包

**复现路径**（`injector/src/index.ts` 注入流程）--插件经 pnpm 正常安装进 profile（`node_modules` 下是真实目录而非链接）后，注入同名包时：

1. `linkExists = lstatSync(linkDir).isSymbolicLink() || lstatSync(linkDir).isDirectory()` → `true`（真实目录）
2. `isHealthyLink(linkDir)` → `false`（旧实现只认符号链接）
3. → `rmSync(linkDir, { recursive: true, force: true })` 删掉整个真实包目录，再 `symlinkSync` 换成指向注入源的 junction

一次注入即毁掉一个包管理器正常安装的包（实测踩坑：dsh-better-sidebar 经 pnpm 装入 profile 后再注入，整包目录差点被删）。

**连带问题**：
- `autoRestore` 的 link 自愈扫描会对真实目录做无谓的删除尝试
- registry 包悬空警告（`非 link 依赖且 junction 异常`）对**每一个** pnpm 安装的真实目录误报，每次启动刷屏

**修复**：真实（非链接）路径一律视为健康--它们是包管理器管理的安装实体，本来就不该走"链接校验 → 删除重建"分支。

## Fix 2：设置页 `settings.section` 渲染契约错误，React #130 崩溃白屏

旧实现 `component: () => ({ render() {...} })` 返回带 `render()` 的普通对象，而宿主 ui-settings 的 `settings.section` 槽期望 **React 渲染函数**（dsh-market 同款契约：`register(descriptor, () => createElement(...))`）。宿主渲染时抛 React #130（`slot entry crashed in 'settings.section'`）→ **设置页整页空白**。

另外 label「插件」与官方插件页重名，改为「插件管理」。修复后 DOM 构建逻辑完全不变，仅宿主槽渲染改为 React 容器。

## 验证（Windows + dsh web 实测）

- `prepare.mjs` 重建后装配：设置页「插件管理」正常渲染、列表/统计 API 正常、控制台零错误
- 注入 / 卸载 / 热重载 / autoRestore 流程不受影响
- registry 包悬空警告不再误报（启动日志干净）

## 备注

- 两个修复各自独立 commit，可分开审阅；Fix 1 是数据破坏级问题（rmSync 真实目录），建议优先
- 本地当前运行的就是这个树（与本 PR 逐字节一致），已连续运行验证