### PR TITLE
fix(assembly): add tool-bash-posix row — POSIX bash registry mismatch

### DIFF
--- a/preset/router-standard/agent.cordis.yml
+++ b/preset/router-standard/agent.cordis.yml
@@ -87,6 +87,15 @@
       name: '@deepseek-ai/dsh-tool-bash'
       disabled: !!js process.platform !== 'win32'
 
+# POSIX: agent presets take over the tool manifest, so the host (dsh-base)
+# tool-bash row never enters a preset session — the bash claimed by STAGES
+# stage 3 (verification) fails with 'unknown tool' on macOS/Linux. Register
+# it here; win32 keeps using the gitbash group row above (platform-mutually
+# exclusive, never double-registered).
+- id: tool-bash-posix
+  name: '@deepseek-ai/dsh-tool-bash'
+  disabled: !!js process.platform === 'win32'
+
 - id: tool-pwsh
   name: '@deepseek-ai/dsh-tool-pwsh'
   disabled: !!js process.platform !== 'win32'


### PR DESCRIPTION
## Symptom (macOS, reproduced)

- System prompt `router-stage` (stage ≥1) claims `Callable now: … bash …`
- `tools_catalog` has **no bash entry** (it is generated from the registry)
- Calling `bash` directly → `Error: unknown tool "bash"`
- `dev_router_status` → `callable(runtime)` has no bash

## Root cause

Agent presets take over the tool manifest — a preset session's tools come from the preset's own `agent.cordis.yml`; the host (dsh-base) `tool-bash` row (POSIX-enabled in dsh-base) never enters a preset session. Cross-check: a headless session (no preset, `agentPreset=None`) has a working bash; a `router-standard` session gets `unknown tool`.

Within the preset manifest, `tool-bash` sits inside the win32-only `gitbash-shell` group (`disabled: platform !== 'win32'`) → **on POSIX no bash row is assembled at all**, while `STAGES`/`STAGE_GUIDES` claim it. Since v1.15.0 the disclosure side is single-truth (stageText feeds from `runtimeCallable`), so the text no longer lies — but the capability gap remains: on POSIX the verification stage assembles no shell, and the claimed bash cannot be registered (`installStageTools` silently skips it).

## Fix

One assembly row after the gitbash group (platform-mutually-exclusive with the win32 row, never double-registered):

```yaml
- id: tool-bash-posix
  name: '@deepseek-ai/dsh-tool-bash'
  disabled: !!js process.platform === 'win32'
```

## Verification (runtime, macOS)

Fresh web session with `agentPreset=router-standard` after applying the row:

1. `tools_catalog` / `tools_help` show the full bash registration (command, timeoutMs, workdir, run_in_background, sandbox_permissions…)
2. Stage 0: bash correctly marked 未解锁 (registered but locked)
3. `phase_advance` → stage 1 → **direct native `bash` call** runs `echo BASH_TOOL_OK` successfully (no run_code substitution)
4. System-prompt "Callable now" includes bash — claims and registry agree

Affects all POSIX users (macOS/Linux) of router-standard since bash moved into the win32-only group.