### PR TITLE
docs+sync: 同步策略首立 + router v1.29 / injector v0.3.4 镜像同步

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dsh-routing-suite — 注入器 × 思维模式路由 套装
 
-一个仓库装齐「运行时手术台 + 思维模式路由预设」：先装注入器（免重启运行时管理层），
-再用它装配 router-standard 预设（任务感知思维模式路由，P1-P23 实测）。
+一个仓库装齐「运行时手术台 + 路由预设」：先装注入器（免重启运行时管理层），
+再用它装配 router-standard 预设（严格 workflow + 阶段化渐进披露 + 交付证据门禁）。persona 路由实验史（P1-P23）见下文。
 
 [中文](README.md) | [English](README.en.md)
 
@@ -39,14 +39,25 @@ Copy-Item -Recurse .\preset\router-spec $target
 
 | 路径 | 仓库 | 版本 | 作用 |
 |---|---|---|---|
-| `injector/` | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | [v0.3.3](https://github.com/yjh051108/dsh-super-injector/releases/tag/v0.3.3) | 运行时注入器：dev_* 工具全家桶（注入/热重载/侧挂转正/卸载/路由自愈）；`github:` 装配由 prepare 钩子自动构建 |
-| `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [v0.3.0 … 主线 v1.19.1/v34](https://github.com/yjh051108/dsh-router-standard/releases/tag/v0.3.0) | 思维模式路由预设：router-standard（分类 persona + 完整 sections）/ router-spec（深度思考优先）。router-pro 为规划中（planned），未随 v0.3.0 发布 |
+| `injector/` | [dsh-super-injector](https://github.com/yjh051108/dsh-super-injector) | [v0.3.4](https://github.com/yjh051108/dsh-super-injector/releases/tag/v0.3.4) | 运行时注入器：dev_* 工具全家桶（注入/热重载/侧挂转正/卸载/路由自愈）；v0.3.4 稳定能力声明迁 systemPrompt.section 通道 + dev_* 清理作用域收窄；`github:` 装配由 prepare 钩子自动构建 |
+| `preset/` | [dsh-router-standard](https://github.com/yjh051108/dsh-router-standard) | [v0.3.0 … 主线 v1.29.0/v34](https://github.com/yjh051108/dsh-router-standard/releases/tag/v0.3.0) | 路由预设：router-standard（固定 RL persona + 阶段化渐进披露 + delivery_check 证据门禁）/ router-spec（深度思考优先，实验）。v1.29 对齐 schema=执行一致 + 保留他方 runtime contexts |
 
 > 版本号以各组件仓库的 git tag 为准（列内链接直达对应 Release）。
 
-两个组件随本仓库统一演进（`injector/` 与 `preset/` 已是仓库内普通目录，内容直接入库）；上游独立仓库 `dsh-super-injector` / `dsh-router-standard` 保留用于独立发布，后续可转镜像/归档。预设安装目录为 `preset/router-standard`（已平铺，无额外嵌套）。
+`injector/` 与 `preset/` 是随本仓库入库的**安装镜像**；预设安装目录为 `preset/router-standard`（已平铺，无额外嵌套）。
 
-## router-standard 预设能力（P1-P23 实测摘要）
+## 同步策略（source of truth）
+
+- **上游独立仓库是发布源**：代码在 `dsh-super-injector` / `dsh-router-standard` 以 PR 演进；
+  本仓库镜像在发布/对齐时**整体复制**更新——同一文件只在一个仓库手改，禁止双向人工演进。
+- **同步动作**：上游 PR 合并后，从两个独立仓库 main 复制对应文件到 `injector/`、`preset/`，提交注明 `sync: <upstream>@<sha>`。
+- **当前待同步**：router-standard v1.29.0（`fix/ctxprompt-alignment`）、dsh-super-injector v0.3.4（`fix/ctxprompt-alignment`）——上游 PR 合并后执行本步。
+- **版本口径**：以独立仓库 CHANGELOG / git tag 为准；本 README 表格保持与上游对齐。
+
+## router-standard 预设能力（P1-P23 实测摘要 · 历史实验线）
+
+> ⚠️ 本表是 persona 路由实验线（v1.19 之前）的历史记录。**当前主线（v1.20+，见 `preset/CHANGELOG.md`）：固定 RL persona + 阶段化渐进披露（零预解锁）
+> + 完成信号晋级 + delivery_check 交付证据门禁**；按任务分类的 persona 路由已退役，此表保留作实验档案。
 
 - **三行为带 + weak 内路由**：spec（计划-集体）/ react（执行者）/ mixed（陷阱，回避）/ weak（模型自分类）
 - **按模型选 persona**：Pro=spec 句+few-shot（区分度 +5.0）；Flash=neutral+classify（+5.7）

--- a/injector/CHANGELOG.md
+++ b/injector/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.3.4 — 提示词/上下文通道对齐（context-engineering + system-prompt-engineering）
+
+- **稳定能力声明 context → section**：静态能力说明（dev_* 通道/形态/使命）从每次 assembly 的 runtime-context snapshot
+  迁到 systemPrompt.section（稳定 system 前缀，fiber 生命周期注册）——动态事实才走 context 通道（通道语义修正）。
+- **固定剧本链移除**：能力说明不再灌注 “dev_plugin_status → … → dev_uninject_plugin” 固定序列，改为声明式指引
+  （无固定调用顺序，按需 tools_help 查询）。
+- **dev_* 清理作用域收窄**：purgeStaleTools 只清本插件历史实例登记过的 dev_*（instanceId + globalThis 所有权表），
+  命名前缀不再是所有权证明——其他插件合法注册的 dev_* 不再被误杀；自重载/热更新的僵尸清除能力不变。
+- **工具描述四件套**：dev_release_plugin 补“何时不用 + 外部副作用 + 用户授权前置”；dev_scaffold_plugin 描述精简
+  （四件套结构，实现流程移出 schema）。
+
+验证：typecheck（tsc --noEmit）；行为面由 3081 测试节点装包验证。
+
 本项目版本与仓库提交对应，格式参照 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
 > **版本以 git tag 为准**：已发布 v0.3.1 / v0.3.3（GitHub Releases 资产）；未打 tag 的

--- a/injector/package.json
+++ b/injector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsh-external/dsh-super-injector",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "超级模组注入器：运行时注入任意本地 DSH 插件包（junction 链接 + loader.create，不碰 patch/package.json/不重启），热重载全家桶 + 开发侧挂区一键转正 + 一键卸载 + 路由自愈 + 插件管理 UI（设置页：列表/卸载/拖入内化），清单持久化重启自动恢复——DSH 生态的 BepInEx 式模组注入入口",
   "private": true,
   "type": "module",

--- a/injector/src/index.ts
+++ b/injector/src/index.ts
@@ -2356,13 +2356,22 @@ export function apply(ctx: AppContext, config: Config): void {
   // 工具的僵尸闭包」（实测：锁永久卡死、新代码永不生效的根因）。
   function safeRegister(tool: any): void {
     try {
-      ctx.effect(() => ctx.tools.register(tool), `dsh-super-injector: ${tool.name ?? 'tool'}`)
+      ctx.effect(() => {
+        ctx.tools.register(tool)
+        const nm = typeof tool?.name === 'string' ? tool.name : ''
+        if (nm.startsWith('dev_')) devOwners.set(nm, instanceId)
+      }, `dsh-super-injector: ${tool?.name ?? 'tool'}`)
     } catch (e) {
       logger.warn('[super-injector] 跳过冲突工具注册: %s', e instanceof Error ? e.message : String(e))
     }
   }
 
-  /** 启动自净：清除历史版本裸注册残留的同名工具（僵尸闭包），再注册新工具。 */
+  /** 实例身份与 dev_* 所有权登记（globalThis 跨实例共享）。作用域边界：命名前缀不是所有权证明——
+   *  只清本插件历史实例登记过的 dev_*，其他插件合法注册的一律保留（v0.3.4）。 */
+  const instanceId = Math.random().toString(36).slice(2, 10)
+  const devOwners: Map<string, string> = (globalThis as any)[Symbol.for('dsh-super-injector.devOwners')] ?? ((globalThis as any)[Symbol.for('dsh-super-injector.devOwners')] = new Map<string, string>())
+
+  /** 启动自净：清除历史实例裸注册残留的本插件 dev_*（僵尸闭包），再注册新工具。 */
   function purgeStaleTools(): void {
     try {
       const toolsSvc = ctx.get('tools') as {
@@ -2374,7 +2383,7 @@ export function apply(ctx: AppContext, config: Config): void {
       const table = toolsSvc.layers?.global?.tools
       if (table && typeof table.keys === 'function') {
         for (const name of table.keys()) {
-          if (typeof name === 'string' && name.startsWith('dev_')) names.push(name)
+          if (typeof name === 'string' && name.startsWith('dev_') && devOwners.get(name) && devOwners.get(name) !== instanceId) names.push(name)
         }
       }
       for (const name of names) {
@@ -2384,7 +2393,7 @@ export function apply(ctx: AppContext, config: Config): void {
         } catch { /* 单项清理失败继续 */ }
       }
       if (names.length > 0) {
-        logger.warn('[super-injector] 已清理 %d 个僵尸工具残留: %s', names.length, names.join(','))
+        logger.warn('[super-injector] 已清理 %d 个历史实例 dev_* 僵尸残留（作用域内，不动他人 dev_*）: %s', names.length, names.join(','))
         auditLog('purge-stale-tools', names.join(','))
       }
     } catch { /* 自净失败不阻塞 */ }
@@ -2822,7 +2831,7 @@ export function apply(ctx: AppContext, config: Config): void {
 
   safeRegister(defineTool({
     name: 'dev_scaffold_plugin',
-    description: '插件生产线：生成四种形态的插件骨架（toolkit 工具包 / daemon-loop 守护循环(timer+LLM 自主 agent loop) / ui-panel UI 面板 / hybrid 混合）——package.json（peerDeps 范围声明不硬编码版本）+ tsconfig + build.sh（DSH_CHECKOUT 自动探测）+ 形态源码（资源挂 ctx.effect 规范）+ 可选 client 骨架。生成后：dev_build_plugin 构建 → dev_inject_plugin 注入。',
+    description: '插件生产线脚手架：生成四种形态插件骨架（toolkit 工具包 / daemon-loop 守护循环 / ui-panel UI 面板 / hybrid 混合，form 参数选择）——package.json + tsconfig + build.sh + 形态源码 + 可选 client 骨架。前置：目标目录不存在或为空。副作用：在 dir 下写入文件。生成后下一步：dev_build_plugin → dev_inject_plugin（流程细节随工具输出给出）。何时不用：已有插件包（含 package.json + lib/）直接 dev_inject_plugin，勿重新脚手架。',
     parameters: {
       dir: { type: 'string', required: true, description: '目标目录（绝对路径，不存在则创建）' },
       name: { type: 'string', required: true, description: '插件名（如 my-tool；或完整包名 @scope/my-tool）' },
@@ -2968,7 +2977,7 @@ export function apply(ctx: AppContext, config: Config): void {
 
   safeRegister(defineTool({
     name: 'dev_release_plugin',
-    description: '插件生产线：发布 GitHub Release——gh release create v<version> <tgz>（tag + 附件 + notes 模板）。依赖：gh CLI 已认证 + git remote 指向目标仓库。返回 release URL。',
+    description: '插件生产线：发布 GitHub Release——gh release create v<version> <tgz>（tag + 附件 + notes 模板）。前置：gh CLI 已认证 + git remote 指向目标仓库。副作用：向外部 GitHub 仓库真实发布（不可逆、公开可见）——仅在用户明确要求发布时调用；只需 tgz 产物则用 dev_build_plugin，不要发布。已存在同 tag 时 gh 会失败，先核对 tag。返回 release URL。',
     parameters: {
       dir: { type: 'string', required: true, description: '插件目录（含 package.json 与 tgz 产物）' },
       version: { type: 'string', description: '版本号（缺省读 package.json version，如 0.0.1）' },
@@ -3188,11 +3197,13 @@ export function apply(ctx: AppContext, config: Config): void {
   // - 动态内容（记忆检索/实时状态）→ 严禁进 system 头部：走消息尾追加
   //   （尾部注入插件即此模式）或 system 最尾，变化只伤自身之后；
   // - 本段 text 必须保持编译期常量——任何每轮变化的动态拼接都会全灭前缀缓存。
-  // ⚠️ 容忍重复注册（实测：自重载 rebuild 时旧 entry 的 context 可能残留，
+  // ⚠️ 通道选择（context-engineering）：稳定能力声明 = systemPrompt.section（稳定 system 前缀，随 fiber 生命周期注册）；
+  //    每次 assembly 变化的当前事实才走 systemPrompt.context（runtime-context snapshot）。v0.3.4 迁移。
+  // ⚠️ 容忍重复注册（实测：自重载 rebuild 时旧 entry 的 section 可能残留，
   // duplicate 会让 apply 整体 failed → 注入器死亡 + 自愈 3 连败）。duplicate
   // 时跳过注册（新实例可运行），比 failed 强。
   try {
-    ctx.systemPrompt.context({
+    ctx.systemPrompt.section({
       name: 'dsh-super-injector',
       order: -90,
       // 引导（首次接触的 agent 从这段获得完整认知）：
@@ -3205,10 +3216,10 @@ export function apply(ctx: AppContext, config: Config): void {
     //    仓库、已注入插件、官方 packages 的服务面与构建模式），不重复造轮子；
     // 5) 使命：若注入器无法支撑此闭环，优先修复注入器。
     // ⚠️ 静态常量文本（缓存原则：静态到头）——严禁动态拼接。
-    text: '本环境装有 dsh-super-injector（dev_* 工具）：任意本地插件包可运行时注入——工具包/守护循环（timer+LLM 自主 agent loop）/UI 面板/混合形态，同一通道；注入即完整生效（host+UI）、可热重载与自重载、卸载即净。插件自身的提示词/工具/循环皆可自我优化；建新插件优先克隆/借鉴/重构生态已有资源（dsh-external 仓库、已注入插件、官方 packages 模式），不重复造轮子。若注入器无法支撑此闭环，优先修复注入器。从零体验路径：dev_plugin_status → dev_self_test → dev_scaffold_plugin → dev_build_plugin → dev_inject_plugin → dev_uninject_plugin。',
+    text: '本环境装有 dsh-super-injector（dev_* 工具）：任意本地插件包可运行时注入——工具包/守护循环（timer+LLM 自主 agent loop）/UI 面板/混合形态，同一通道；注入即完整生效（host+UI）、可热重载与自重载、卸载即净。插件自身的提示词/工具/循环皆可自我优化；建新插件优先克隆/借鉴/重构生态已有资源（dsh-external 仓库、已注入插件、官方 packages 模式），不重复造轮子。若注入器无法支撑此闭环，优先修复注入器。dev_* 工具说明按需查询（tools_help / dev_plugin_status），无固定调用顺序：先 dev_plugin_status 看当前装配、dev_self_test 自检，再按需脚手架/构建/注入。',
     })
   } catch (e) {
-    logger.warn('[super-injector] systemPrompt.context 重复注册容忍（跳过，新实例继续运行）: %s', e instanceof Error ? e.message : String(e))
+    logger.warn('[super-injector] systemPrompt.section 重复注册容忍（跳过，新实例继续运行）: %s', e instanceof Error ? e.message : String(e))
   }
 
   logger.info('[super-injector] 就绪：watch %d 目录（%dms），autoRestore=%s', watches.length, intervalMs, String(config.autoRestore))

--- a/preset/CHANGELOG.md
+++ b/preset/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.29.0 — 上下文 / 提示词工程对齐（context-engineering + system-prompt-engineering 双技能吸收）
+
+**schema ↔ 执行一致（system-prompt-engineering）**：delivery_check 删除死参数与矛盾承诺——不再内置
+headless smoke，url 改为页面门禁标记（evidence 须含 ≥1 项 reviewed:true 视觉证据），移除
+requireSmoke / timeoutMs / virtualTimeMs / retry；此前“传 url 无条件 FAIL”陷阱消失（schema=执行，测试固化）。
+
+**上下文通道正确（context-engineering）**：装配不再无差别清空他方 runtime contexts——三处
+contexts: []（首轮 / 晋级 / SDK 分支）全除，只保留本 preset 拥有的 sections；集成测试以
+foreign-context fixture 固化“他方动态事实必须存活”。
+
+**注意力税收敛（反剧本化）**：四阶段指南压缩为声明式 Object / Link / Action；planning 阶段不再指引
+调用验证阶段才解锁的 subagent / workflow（指引与执行可用性一致）。
+
+**阶段边界确定性**：auto-advance 的 stageAtTime 由墙钟 Date.now() 改为“已消费事件最大时间 +1”——事件时间严格递增的宿主语义不变，测试可注入显式时间戳（修复同毫秒墙钟碰撞导致的 flaky 晋级测试）。
+
+**版本线**：v34 与 mjs 镜像同步；ROUTER_VERSION → v1.29.0；spec preset 同步 contexts 保留。
+
+验证：router.test + router.integration.test 全绿；selftest PASS。
+
 ## v1.27.0 — 隔离与并行（注意力工程 · 支柱4）
 
 **支柱4 隔离与并行**：当两个独立关注点污染单线程、或一个子问题吞噬主线预算时，用 subagent/workflow

--- a/preset/README.md
+++ b/preset/README.md
@@ -9,19 +9,17 @@
 
 ---
 
-## 当前状态（v1.19.1，2026-08-24 · 研发线，尚未发布）
+## 当前状态（v1.29.0，2026-08-25 · 研发线，尚未发布）
 
-**Router Standard 处于「严格 workflow」研发线**（以 CHANGELOG 为准，版本线文件 `router-bootstrap-v34.mjs`）：
+**Router Standard 处于「严格 workflow + 渐进披露」研发线**（以 CHANGELOG 为准，版本线文件 router-bootstrap-v34.mjs）：
 
 - **严格阶段 workflow**：完成信号驱动晋级（0→1 需澄清/计划、1→2 需计划锁定、2→3 需交付自检），
-  阶段 0 强制对齐（歧义先 `ask_user_question`、复杂任务先 `todo_write`）；"工具名/文本即跳级"已删除。
-- **任务回显**：`stageText` 新增 `Task: <首条真实用户消息>`——模型每轮都看得清在为什么事工作，不跑题。
-- **渐进披露**：阶段化解锁 + 两档预放 + 直达语义 + 交付全量开放；`tools_catalog` 全量索引 / `tools_help` 完整 schema；
-  已删除 `all:true`（无全量出口，未解锁工具不进入视野）。
-- **标准模式基底**：native 直调（无 PTC/run_code 包装，SDK 全量段不存在，工具面注意力税大幅下降）。
-- **页面验证内置**：`dev_page_check` = 截图 + DOM smoke + **console/pageerror/title/selector/scale**；
-  `{js:…}` 模式 = 本地 JS 引擎（零外部 node 依赖）；external 证据一等公民。
-- **描述 ⇄ 行为对齐**：`presentation=native` 自检、阶段文案只说真话、平台事实（win32 以 Git Bash 私有 shell seam 为准）。
+  阶段 0 强制对齐（歧义先 ask_user_question、复杂任务先 todo_write）。
+- **渐进披露（零预解锁 v1.20）**：每阶段只见当前档工具，未解锁不点名；tools_catalog 轻索引 + tools_help 按需完整 schema。
+- **native 直调基底**：无 PTC/run_code 包装，工具面注意力税从 39K 落到当前档。
+- **交付 gate（v1.29 对齐）**：delivery_check 校验文件/编码/证据门禁，不内置浏览器——页面视觉验证由模型用 bash 自测（headless 截图 + read_image）并以 reviewed:true 视觉证据入 evidence；对模型暴露的 schema 与执行完全一致。
+- **上下文通道（v1.29）**：装配保留他方 runtime contexts，只管理本 preset 拥有的 sections；阶段事实经 router-stage section 呈现。
+- **描述 ⇄ 行为对齐**：presentation=native 自检、阶段文案只说真话、平台事实（win32 以 Git Bash 私有 shell seam 为准）。
 - **主动性引导**：Proactivity 常驻段（自检信号，不是停手命令）；压力感应器已退役。
 
 配套预设：**router-react（v17）/ router-spec（v10）**（基于标准模式的两大执行预设，均支持首轮读图）；

--- a/preset/docs/context-prompt-alignment.md
+++ b/preset/docs/context-prompt-alignment.md
@@ -1,0 +1,54 @@
+# context-prompt-alignment（v1.29 设计说明）
+
+> 本文件记录 v1.29.0 改动的技能依据与刻意不做的事。技能源：context-engineering（通道/生命周期/权威）、
+> system-prompt-engineering（sections/描述/schema 组织）、plugin-dev-paradigm（形态边界）。
+
+## 改动一：delivery_check schema ↔ 执行一致
+
+**依据**（system-prompt-engineering）：描述说能做、执行层不能做是最大反模式。旧 schema 承诺
+headless smoke / url 必传 / timeout / retry，而 v1.23 起实现已不跑浏览器；且 url+requireSmoke
+在实现里无条件加 FAIL——严格遵守 schema 的模型永远过不了页面 gate。
+
+**改法**：删除死参数（requireSmoke / timeoutMs / virtualTimeMs / retry，含 shim 注册）；url 降级为
+页面门禁标记（有 url ⇒ evidence 须含 ≥1 项 reviewed:true 视觉证据，由实现 490-493 行强制）；
+DESC 与参数描述改写为“gate 只校验证据，浏览器验证由你自己做”。main 注册与 own-layer shim 同源。
+
+**不做的**：不把 smoke 重新内置回 delivery_check——v1.23 的决策（模型自测 + evidence）保留，
+恢复浏览器的 ROI 为负（preset 不拥有宿主浏览器资源；形态边界见 plugin-dev-paradigm）。
+
+## 改动二：装配保留他方 runtime contexts
+
+**依据**（context-engineering）：只清理自己拥有且有害的。旧实现每次 assembly 返回 contexts: []，
+把其他插件合法贡献的当前事实（workspace/mode/状态）无差别清空——跨插件作用域污染。
+
+**改法**：三处（首轮 / 晋级 SDK 分支 / 普通晋级）全除 contexts 覆写；本 preset 只替换 sections 与工具面。
+集成测试新增 foreign-context fixture，断言他方 context 在首轮与晋级后均存活。
+
+## 改动三：阶段指南声明式化
+
+**依据**：四阶段指南常驻 system prompt（每轮注意力税）；旧文本是数百字流程剧本（记忆策略/subagent
+策略/失败归因/页面验证教程），与 schema 精简目标自相矛盾；且 planning 指引建议调用验证阶段才解锁的
+subagent/workflow（描述=执行可用性不一致）。
+
+**改法**：每个指南保留 Object（当前阶段+工具）/ Link（解锁顺序）/ Action（完成信号与门禁），压缩散文；
+planning 段改为“subagent/workflow 验证阶段解锁，当前先把关注点拆成条目”。
+
+## 刻意不做（RFC，待宿主能力）
+
+- **RFC-1 stage → session event**：阶段仍是 sidecar stages.json（模型可见状态不可从 session log 重建）。
+  完整修复需宿主支持 router/stage-* 自定义事件类型并持久化——属 dsh 主机层能力，非 preset 可独立完成。
+  暂以 dev_router_status + router-stage section 缓解；列入后续 RFC。
+- **RFC-2 router-stage 从 section 迁 PromptContext**：阶段事实每次 assembly 变化，语义上更接近
+  runtime context；但迁移会改变 KV 前缀稳定性与压缩行为，需先在宿主 API 上验证动态 context provider
+  的重算语义再动。暂保持 section（稳定性优先）。
+- **RFC-3 delivery 结果门禁**：autoAdvance 仍按“调用了 delivery_check”推进（stage 2→3）。刻意保留——
+  阶段 3 解锁修复工具（bash/jobs），若以 PASS 为前提会困住失败的模型；真正的门禁在 delivery_check 结果
+  与 stageText“do NOT declare delivered”。不改为结果门控。
+- **镜像与 suite**：preset 内 v34（挂载）与 mjs（镜像）同步维护；suite 同步由 dsh-routing-suite 的
+  sync 策略负责（见该仓库 README），本仓库不再双份演进。
+
+## 验证
+
+- 单元/集成：router.test.mjs（deliveryCheck 新契约 + 证据门禁用例）+ router.integration.test.mjs（contexts 保留）
+- 自检：probe/selftest.mjs
+- 真机验证（安装进 3081 测试环境的行为面）由 A2A 测试节点执行，本 PR 不自行部署。

--- a/preset/router-spec/router-bootstrap-v10.mjs
+++ b/preset/router-spec/router-bootstrap-v10.mjs
@@ -20,7 +20,7 @@
  *
  * ── v0.3.0: real-assembly-chain fixes ─────────────────────────────────────
  *
- * See the identical notes in `router-standard/router-bootstrap.mjs`:
+ * See the identical notes in `preset/router-standard/router-bootstrap.mjs`:
  * first-turn classification now runs off `agent/inbox/claimed` (#13), and
  * near-field guidance is injected at `agent/pre-step` into the SAME request
  * as the user message (#34/#36/#55). The promoted branch restores the full
@@ -148,7 +148,7 @@ export function apply(ctx, config) {
       // touching anything — standard mode restores the full sections/contexts;
       // spec mode keeps its classified persona over the untrimmed list.
       if (routerMode === 'standard') return assembled
-      return { ...assembled, sections, contexts: [] }
+      return { ...assembled, sections } // v1.29: 保留他方 runtime contexts
     }
 
     const available = new Set(assembled.tools.map((tool) => tool.name))
@@ -164,9 +164,8 @@ export function apply(ctx, config) {
     return {
       ...assembled,
       sections,
-      contexts: [],
       tools: assembled.tools.filter((tool) => core.has(tool.name)),
-    }
+    } // v1.29: 保留他方 runtime contexts
   })
 
   // ── near-field routing guidance for weak mode (P14/P16/P17/P19/P20) ─────

--- a/preset/router-spec/router-bootstrap.mjs
+++ b/preset/router-spec/router-bootstrap.mjs
@@ -20,7 +20,7 @@
  *
  * ── v0.3.0: real-assembly-chain fixes ─────────────────────────────────────
  *
- * See the identical notes in `router-standard/router-bootstrap.mjs`:
+ * See the identical notes in `preset/router-standard/router-bootstrap.mjs`:
  * first-turn classification now runs off `agent/inbox/claimed` (#13), and
  * near-field guidance is injected at `agent/pre-step` into the SAME request
  * as the user message (#34/#36/#55). The promoted branch restores the full
@@ -148,7 +148,7 @@ export function apply(ctx, config) {
       // touching anything — standard mode restores the full sections/contexts;
       // spec mode keeps its classified persona over the untrimmed list.
       if (routerMode === 'standard') return assembled
-      return { ...assembled, sections, contexts: [] }
+      return { ...assembled, sections } // v1.29: 保留他方 runtime contexts
     }
 
     const available = new Set(assembled.tools.map((tool) => tool.name))
@@ -161,9 +161,8 @@ export function apply(ctx, config) {
     return {
       ...assembled,
       sections,
-      contexts: [],
       tools: assembled.tools.filter((tool) => core.has(tool.name)),
-    }
+    } // v1.29: 保留他方 runtime contexts
   })
 
   // ── near-field routing guidance for weak mode (P14/P16/P17/P19/P20) ─────

--- a/preset/router-standard/router-bootstrap-v34.mjs
+++ b/preset/router-standard/router-bootstrap-v34.mjs
@@ -1,5 +1,5 @@
 /**
- * router-bootstrap (standard v1.20.0): progressive disclosure with zero pre-unlock — each stage sees only its own tools (anti-"haste" main line).
+ * router-bootstrap (standard v1.29.0): progressive disclosure with zero pre-unlock — each stage sees only its own tools (anti-"haste" main line).
  *
  * 时序（用户定稿）：
  *   T0 首轮 = 纯 RL 句（46 字符）+ phase_begin（唯一确认工具，native；稳定 we）
@@ -54,14 +54,14 @@ function toJsonSchema(spec) {
 }
 
 const RL_PERSONA = 'You are a helpful software engineer assistant.'
-const ROUTER_VERSION = 'v1.20.0'
+const ROUTER_VERSION = 'v1.29.0'
 /* 描述单源（v1.13 审计修复）：main 注册与 own-layer shim 读同一份，杜绝双份漂移。 */
 const DESC = {
   toolsCatalog: '渐进式披露一级：默认只列当前阶段可调工具（未解锁不点名、不预告后续工具）；query 单点白盒（命中未解锁才给相关行，带解锁阶段/交付期标注）；无全量出口——严格按阶段推进，未解锁工具名称不进入视野。行标注=运行时真绑定。',
   toolsHelp: '渐进式披露二级：单个工具的完整 schema（含解锁阶段提示）。查询本身是主动行为——可查未解锁工具详情，但调用会被拒绝。',
   phaseAdvance: '闯关推进：声明当前阶段已完成，进入下一阶段（解锁新工具 + 阶段提示）。逐级推进（一次一级，不跳级）。仅在明确完成本阶段工作时调用。进入验证/交付阶段后：先 delivery_check(file[, url], evidence)，PASS 才可宣告完成。',
   routerStatus: 'Show the current routing state (phase, band, persona, unlocked tools, override). No arguments — call as tools["dev_router_status"]({}).',
-  deliveryCheck: '交付 gate（阶段出口契约）。检查清单：file-exists / file-nonempty / encoding-utf8（必查）+ headless-smoke（页面类必查：传 url；requireSmoke 默认 true——省略 url 会 FAIL，不再可绕过）+ delivery-evidence。evidence 结构（tools_help 同源）：{ items: [{ label, kind ∈ file|page|image|run|test|text|external|numeric, target?（file/page/image/test 必填路径）, result?（run/text/external 必填文本）, external?（kind=external：target=输出路径或命令、result=结果摘要）, reviewed?: true（page/image 视觉类必须人工复核） }] }。⚠️ 全部 PASS 才允许宣告完成；任一 FAIL 修复后重跑，不允许绕过。',
+  deliveryCheck: '交付 gate（阶段出口契约）。检查清单：file-exists / file-nonempty / encoding-utf8（必查）+ delivery-evidence（证据门禁）。页面交付物：传 url 标记（http(s):// / file:// / 裸路径），gate 要求 evidence 含 ≥1 项 reviewed:true 的视觉证据（kind ∈ page|image|external）——delivery_check 不内置浏览器，页面视觉验证由你自己做（bash 起 headless Chrome/Playwright 截图 + read_image 复核），gate 只校验证据。evidence 结构（tools_help 同源）：{ items: [{ label, kind ∈ file|page|image|run|test|text|external|numeric, target?（file/page/image/test 必填路径）, result?（run/text/external 必填文本）, external?（kind=external：target=输出路径或命令、result=结果摘要）, reviewed?: true（page/image 视觉类必须人工复核） }] }。⚠️ 全部 PASS 才允许宣告完成；任一 FAIL 修复后重跑，不允许绕过。',
 }
 const PROGRESSIVE_DECL =
   'We hold a full tool registry (see tools_catalog for the live count), revealed in phases. tools_catalog lists every tool (name + summary + [phase mark] + param names); tools_help <name> returns any tool\'s complete spec. We query on demand and call precisely. '
@@ -117,10 +117,10 @@ export function windowFor(stage) { return Math.min(stage + 1, STAGES.length) }
  *  v1.5：caps 提示 / write-edit 只用 path / shell 真实语义 / dev_page_check。
  *  v1.6：预放两档 + 直达语义（写 HTML 直给任务零路由成本）；跨语言转义提醒。 */
 const STAGE_GUIDES = [
-  'Phase: understanding. Unlocked: this stage only — read/glob/grep/web_search/ask_user_question + memory recall/verify/respond. Ground first: recall → verify → read/ask. Do this stage properly and think broadly — do not settle on the first obvious reading. Break the request into its dimensions (what the user wants, how features should behave, what "good" looks like) and surface the genuinely ambiguous ones: a word like "拖拽" could mean reorder, drag-to-recategory, or both; "瀑布流" could mean masonry columns or JS-grid; persistence is often unspecified. **Decide each ambiguity by its impact:** if you can infer the common meaning and only one interpretation is reasonable for a deliverable, state that assumption clearly in one sentence (so the user can correct it) and continue — but if two or more interpretations would materially change the result (reorder vs recategory; persist vs not), ask ONE focused ask_user_question per such ambiguity, with concrete options. Do not under-ask (assume everything) nor over-ask (interrogate trivia) — aim for the questions that actually change the artifact. This is a deep-thinking stage: if the task is complex, also record a plan (todo_write). **Complete when: you understand the task (assumptions stated, or key ambiguities answered) — and, if complex, a plan is recorded. No alignment, no advancement.** → Done? Understood (stated assumption / question answered / plan recorded) → next stage.',
-  'Phase: planning. Unlocked: todo_write/exit_plan_mode + memory review (search/open). Do this stage properly: design the approach, cover edge cases, define what "done" means, and decide acceptance criteria — not just list steps. **Attention reclamation (v1.26): assetize your context — keep the task goal + the current decision + the live evidence in the attention window; sink settled exploration/details into memory (engram_store) instead of holding them all; let stale, superseded, or resolved threads truly drop (fresh context recovers attention). Do not hold "everything might be useful" in mind — that is attention leakage, not diligence.** **Isolation & parallel (pillar 4): when two independent concerns are polluting one thread, or a sub-problem is eating the mainline budget, push it into a subagent / workflow (independent context) instead of keeping it in the same stream — a focused subagent holds its own attention so your mainline stays on the critical path.** **Complete when: the plan is thorough enough that the design is decision-complete (what to build, how it fits, what success looks like), recorded via todo_write or presented via exit_plan_mode.** Only this lets you enter development. Note: a completion signal (todo_write / exit_plan_mode) AUTO-advances to the next phase — do NOT call phase_advance after it, or you will skip a phase. → Done? Plan is decision-complete and locked (todo_write / exit_plan_mode) → develop (auto).',
-  'Phase: development. Unlocked: write/edit/str_replace_editor + memory write (store/link). Re-read before re-edit (editor enforces fresh read); write/edit results carry FULL before/after text — take path/operation, inspect with grep/read. Do this stage properly: make the artifact real, self-check it against the plan and the acceptance criteria, and do not declare it done until it actually passes its own check. **Avoid local-optima (v1.22): keep the WHOLE artifact working while you iterate. If you find yourself re-fighting the same detail for several rounds with no convergence (e.g. a finite-difference sign, a conservation drift), step back: (1) is this detail blocking the overall deliverable, or is it polish? (2) preserve a working version; iterate on the detail in parallel, not by stalling the whole. (3) if a detail resists, finish the rest and re-attack it fresh — do not let one stubborn sub-problem stall the deliverable.** **Complete when: the artifact exists and passes its self-check — then enter verification via delivery_check (completion signal) or phase_advance.** → Done? Self-check passes → delivery_check → verification.',
-  'Phase: verification → delivery gate. Unlocked: pwsh/bash/read_image/jobs + delivery_check. Windows: bash = Git Bash (first-class), pwsh for PowerShell; Git Bash may need the one-shot sandbox escalation (approval=never: if denied, report it — never bypass). Page verify with your OWN tools: run a headless browser/playwright via bash (or install one), screenshot + read_image each shot (reviewed:true) to visually confirm. **On verification failure, hold a quick hypothesis-audit (guidance, not a hard block): before touching the implementation, name in one line (a) which assumption you are now re-checking, (b) what NEW evidence you just gained — this turns "doubt the hypothesis" from a prompt into a habit. If the code is actually correct, say so and move on (do not manufacture a bug to justify rework).** Then check gates/evidence. Do this stage properly: verify the real artifact, not a summary of it — check evidence, look for defects, review the visuals honestly. **Gate: delivery_check must PASS — evidence manifest required; missing evidence/unreviewed visuals = FAIL.**',
+  'Phase: understanding. Unlocked: this stage only — read/glob/grep/web_search/ask_user_question + memory recall/verify/respond. Ground first: recall → verify → read/ask. Think broadly — do not settle on the first reading. Break the request into dimensions and decide each ambiguity by impact: one reasonable reading → state the assumption in one sentence and continue; two+ readings that materially change the result → ONE ask_user_question per ambiguity (concrete options). Do not under-ask (assume everything) nor over-ask (interrogate trivia). Complex task → record a plan (todo_write). **Complete when the task is understood (assumptions stated / key ambiguities answered) and, if complex, a plan is recorded. No alignment, no advancement.** → Done? Understood → next stage.',
+  'Phase: planning. Unlocked: todo_write/exit_plan_mode + memory review (search/open). Design the approach: cover edge cases, define "done" and acceptance criteria — not just steps. **Attention (v1.26): hold task goal + current decision + live evidence; sink settled detail into memory (engram_store); let stale/superseded threads drop — attention leakage is not diligence.** **Isolation (v1.27): an independent concern polluting this thread → split it into its own todo now; subagent/workflow 独立上下文在验证阶段才解锁，届时用它隔离，当前阶段先把关注点拆成条目。** **Complete when the plan is decision-complete and locked (todo_write / exit_plan_mode). Only this lets you enter development. Completion signal AUTO-advances — do NOT call phase_advance after it (would skip a phase).** → Done? Plan locked → develop (auto).',
+  'Phase: development. Unlocked: write/edit/str_replace_editor + memory write (store/link). Re-read before re-edit; write/edit results carry FULL before/after text — take only path/operation, inspect with grep/read. Make the artifact real and self-check against the plan + acceptance criteria; do not declare done until it passes its own check. **Avoid local-optima (v1.22): keep the WHOLE artifact working — a stubborn detail is polish unless it blocks the deliverable; finish the rest and re-attack it fresh.** **Complete when the artifact exists and passes its self-check → enter verification via delivery_check (completion signal) or phase_advance.** → Done? Self-check passes → delivery_check → verification.',
+  'Phase: verification → delivery gate. Unlocked: pwsh/bash/read_image/jobs + delivery_check. Windows: bash = Git Bash (first-class), pwsh for PowerShell; one-shot sandbox escalation denied → report, never bypass. Page verify with YOUR OWN tools: bash headless Chrome/playwright screenshot + read_image each shot (reviewed:true). **On failure: one-line hypothesis audit — (a) which assumption are you re-checking, (b) what NEW evidence did you gain; if the code is correct, say so and move on (do not manufacture a bug).** **Gate: delivery_check must PASS — evidence manifest required; missing evidence/unreviewed visuals = FAIL.** → Done? Gate passed → delivered.',
 ]
 
 /** 阶段文本（we-form——you-form 是 let me 吸引子）。
@@ -434,10 +434,7 @@ export async function deliveryCheck(ctx, args) {
   // v1.23（方案A·大道至简）：delivery_check 不再自跑 headless smoke（此前复用 dev_page_check/pageCheckRun，反复出bug）。
   // 页面交付物的视觉验证交给**模型用 bash 自测**（playwright/headless Chrome 截图 + read_image 视觉确认），
   // 并在 evidence 里给 visual proof（kind=image, reviewed:true）。delivery_check 校验 evidence 门禁，而非自已渲染。
-  const requireSmoke = args?.requireSmoke !== false
-  if (args?.url && requireSmoke) {
-    checks.push({ name: 'page-verify', pass: false, detail: 'visual verify the page with bash (headless Chrome/playwright screenshot) + read_image (reviewed:true) into evidence — delivery_check gates the evidence, not a built-in browser' })
-  }
+  /* v1.29：删除旧“url+requireSmoke→无条件 page-verify FAIL”陷阱——视觉证据要求已由下方 delivery-evidence（reviewed:true）覆盖；无内置 smoke 判定。
   /* 证据门禁（正式交付契约——v1.14 规范化：schema 写清进工具描述，不再让模型读源码）：
    * evidence.items[] 每项: { label, kind ∈ file|page|image|run|test|text|external|numeric, target?（file/page/image/test 必填路径）,
    *   result?（run/text 必填文本）, reviewed?: true（page/image 视觉类必须人工复核过）}
@@ -639,7 +636,7 @@ export function apply(ctx, config) {
 
     if (!promoted) {
       // 首轮：无 restrict + 工具面只留 phase_begin（纯 RL 条件 = 稳定 we）
-      return { ...assembled, sections: baseSections, contexts: [], tools: assembled.tools.filter((tool) => tool.name === 'phase_begin') }
+      return { ...assembled, sections: baseSections, tools: assembled.tools.filter((tool) => tool.name === 'phase_begin') } // v1.29: 保留他方 runtime contexts（context-engineering：只清理自己拥有且有害的）
     }
 
     // promoted：官方 sections 回流（persona 保持 RL 句）+ 引导带宽控 + 阶段声明 + 常驻段
@@ -661,10 +658,10 @@ export function apply(ctx, config) {
     if (available.has('run_code')) {
       const staged = buildStagedSdk(sections, stage)
       if (staged) {
-        return { ...assembled, sections: sections.map((s) => (s.name === 'tools:sdk' ? staged : s)), contexts: [] }
+        return { ...assembled, sections: sections.map((s) => (s.name === 'tools:sdk' ? staged : s)) }
       }
     }
-    return { ...assembled, sections, contexts: [] }
+    return { ...assembled, sections }
   })
 
   // ── 自主路由（pre-step）：调用下一档工具 → 自动推进阶段 ──────────────────
@@ -676,7 +673,7 @@ export function apply(ctx, config) {
     const sid = agent.session.id
     const st = (ensureStage()[sid] ??= { stage: 0, guided: false })
     const stageAt = st.stageAtTime ?? 0
-    const toolCalls = (agent.session.events || []).filter((e) => (e.time === undefined || e.time >= stageAt) && (e.type === 'tool/call' || e.type === 'tool/code-dispatch')).map((e) => ({ name: e.data?.name || e.data?.toolName || '', args: toolArgs(e.data) }))
+    const toolCalls = (agent.session.events || []).filter((e) => (e.time === undefined || e.time >= stageAt) && (e.type === 'tool/call' || e.type === 'tool/code-dispatch')).map((e) => ({ name: e.data?.name || e.data?.toolName || '', args: toolArgs(e.data), time: e.time }))
     // v1.17.2：被拒的锁定工具调用（如阶段 0 调 bash → unknown tool）不算行为信号——
     // 只有当前阶段真实可调（view.visible）的工具调用才触发直达推进。
     let advanceCalls = toolCalls
@@ -688,7 +685,10 @@ export function apply(ctx, config) {
     const nextStage = autoAdvance(st.stage, advanceCalls, text)
     if (nextStage > st.stage) {
       st.stage = nextStage
-      st.stageAtTime = Date.now()
+      // v1.29：阶段边界 = 已消费事件最大时间 +1（确定性）——事件时间严格递增的宿主语义不变；
+      // 测试可注入显式递增时间戳，不再受同毫秒墙钟碰撞影响（此前 Date.now() 与事件同 ms 时会重算已消费信号）。
+      const consumedMax = Math.max(0, ...toolCalls.map((c) => (Number.isFinite(c.time) ? Number(c.time) : 0)))
+      st.stageAtTime = consumedMax > 0 ? consumedMax + 1 : Date.now()
       st.lastAdvance = { at: Date.now(), reason: 'auto:' + advanceCalls.map((c) => c.name).filter(Boolean).join(',') }
       saveStageState()
       applyStageRestrict(agent, nextStage)
@@ -902,11 +902,7 @@ export function apply(ctx, config) {
     description: DESC.deliveryCheck,
     parameters: {
       file: { type: 'string', required: true, description: '交付物文件路径（绝对路径或工作区相对路径）' },
-      url: { type: 'string', description: '页面交付物必传：http(s):// / file:// / 裸路径（自动编码）——省略时 headless-smoke 判 FAIL（requireSmoke: false 才可跳过，仅限脚本/文档类非页面产物）' },
-      requireSmoke: { type: 'boolean', description: '默认 true：页面产物必须跑 headless smoke（避免"省略 url 即绕过"）。非页面产物传 false' },
-      timeoutMs: { type: 'number', description: 'smoke 硬超时毫秒（默认 20000）' },
-      virtualTimeMs: { type: 'number', description: 'smoke 虚拟时间预算（默认 8000）' },
-      retry: { type: 'boolean', description: 'smoke 失败时自动重试一次（默认 true，降分辨率+双倍虚拟时间）' },
+      url: { type: 'string', description: '页面交付物标记：http(s):// / file:// / 裸路径。传了即按页面门禁——delivery-evidence 须含 ≥1 项 reviewed:true 视觉证据（kind ∈ page|image|external，见 evidence）；省略 = 非页面门禁（文件/证据门禁仍生效）。' },
       evidence: { type: 'object', description: '通用证据清单。结构（唯一权威）：{ items: [{ label, kind ∈ file|page|image|run|test|text|external|numeric, target?（file/page/image/test 必填路径）, result?（run/text/external 必填文本）, reviewed?: true（page/image 视觉类必须人工复核过） }] }。页面交付物要求至少一项 reviewed:true 的视觉证据；为空则 delivery-evidence 判 FAIL。', properties: {
         items: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
           kind: { type: 'string', enum: ['file','page','image','run','test','text','external','numeric'] },
@@ -1043,9 +1039,7 @@ export function apply(ctx, config) {
       description: DESC.deliveryCheck,
       parameters: {
         file: { type: 'string', required: true, description: '交付物文件路径' },
-        url: { type: 'string', description: '可选页面地址（自动编码）' },
-        timeoutMs: { type: 'number' }, virtualTimeMs: { type: 'number' }, retry: { type: 'boolean' },
-        requireSmoke: { type: 'boolean', description: '默认 true：页面产物必须 smoke（省略 url 即 FAIL，不再可绕过）' },
+        url: { type: 'string', description: '页面交付物标记：http(s):// / file:// / 裸路径——传了即要求 evidence 含 ≥1 项 reviewed:true 视觉证据（页面门禁）' },
         evidence: { type: 'object', description: '证据清单（结构见 tools_help）：{ items: [{ label, kind ∈ file|page|image|run|test|text|external|numeric, target?, result?, reviewed? }] }——页面类要求至少一项 reviewed:true 视觉证据', properties: {
           items: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
             kind: { type: 'string', enum: ['file','page','image','run','test','text','external','numeric'] },

--- a/preset/router-standard/router-bootstrap.mjs
+++ b/preset/router-standard/router-bootstrap.mjs
@@ -54,14 +54,14 @@ function toJsonSchema(spec) {
 }
 
 const RL_PERSONA = 'You are a helpful software engineer assistant.'
-const ROUTER_VERSION = 'v1.20.0'
+const ROUTER_VERSION = 'v1.29.0'
 /* 描述单源（v1.13 审计修复）：main 注册与 own-layer shim 读同一份，杜绝双份漂移。 */
 const DESC = {
   toolsCatalog: '渐进式披露一级：默认只列当前阶段可调工具（未解锁不点名、不预告后续工具）；query 单点白盒（命中未解锁才给相关行，带解锁阶段/交付期标注）；无全量出口——严格按阶段推进，未解锁工具名称不进入视野。行标注=运行时真绑定。',
   toolsHelp: '渐进式披露二级：单个工具的完整 schema（含解锁阶段提示）。查询本身是主动行为——可查未解锁工具详情，但调用会被拒绝。',
   phaseAdvance: '闯关推进：声明当前阶段已完成，进入下一阶段（解锁新工具 + 阶段提示）。逐级推进（一次一级，不跳级）。仅在明确完成本阶段工作时调用。进入验证/交付阶段后：先 delivery_check(file[, url], evidence)，PASS 才可宣告完成。',
   routerStatus: 'Show the current routing state (phase, band, persona, unlocked tools, override). No arguments — call as tools["dev_router_status"]({}).',
-  deliveryCheck: '交付 gate（阶段出口契约）。检查清单：file-exists / file-nonempty / encoding-utf8（必查）+ headless-smoke（页面类必查：传 url；requireSmoke 默认 true——省略 url 会 FAIL，不再可绕过）+ delivery-evidence。evidence 结构（tools_help 同源）：{ items: [{ label, kind ∈ file|page|image|run|test|text|external|numeric, target?（file/page/image/test 必填路径）, result?（run/text/external 必填文本）, external?（kind=external：target=输出路径或命令、result=结果摘要）, reviewed?: true（page/image 视觉类必须人工复核） }] }。⚠️ 全部 PASS 才允许宣告完成；任一 FAIL 修复后重跑，不允许绕过。',
+  deliveryCheck: '交付 gate（阶段出口契约）。检查清单：file-exists / file-nonempty / encoding-utf8（必查）+ delivery-evidence（证据门禁）。页面交付物：传 url 标记（http(s):// / file:// / 裸路径），gate 要求 evidence 含 ≥1 项 reviewed:true 的视觉证据（kind ∈ page|image|external）——delivery_check 不内置浏览器，页面视觉验证由你自己做（bash headless Chrome/Playwright 截图 + read_image 复核），gate 只校验证据。evidence 结构（tools_help 同源）：{ items: [{ label, kind ∈ file|page|image|run|test|text|external|numeric, target?（file/page/image/test 必填路径）, result?（run/text/external 必填文本）, external?（kind=external：target=输出路径或命令、result=结果摘要）, reviewed?: true（page/image 视觉类必须人工复核） }] }。⚠️ 全部 PASS 才允许宣告完成；任一 FAIL 修复后重跑，不允许绕过。',
 }
 const PROGRESSIVE_DECL =
   'We hold a full tool registry (see tools_catalog for the live count), revealed in phases. tools_catalog lists every tool (name + summary + [phase mark] + param names); tools_help <name> returns any tool\'s complete spec. We query on demand and call precisely. '
@@ -117,10 +117,10 @@ export function windowFor(stage) { return Math.min(stage + 1, STAGES.length) }
  *  v1.5：caps 提示 / write-edit 只用 path / shell 真实语义 / dev_page_check。
  *  v1.6：预放两档 + 直达语义（写 HTML 直给任务零路由成本）；跨语言转义提醒。 */
 const STAGE_GUIDES = [
-  'Phase: understanding. Unlocked: this stage only — read/glob/grep/web_search/ask_user_question + memory recall/verify/respond. Ground first: recall → verify → read/ask. Do this stage properly and think broadly — do not settle on the first obvious reading. Break the request into its dimensions (what the user wants, how features should behave, what "good" looks like) and surface the genuinely ambiguous ones: a word like "拖拽" could mean reorder, drag-to-recategory, or both; "瀑布流" could mean masonry columns or JS-grid; persistence is often unspecified. **Decide each ambiguity by its impact:** if you can infer the common meaning and only one interpretation is reasonable for a deliverable, state that assumption clearly in one sentence (so the user can correct it) and continue — but if two or more interpretations would materially change the result (reorder vs recategory; persist vs not), ask ONE focused ask_user_question per such ambiguity, with concrete options. Do not under-ask (assume everything) nor over-ask (interrogate trivia) — aim for the questions that actually change the artifact. This is a deep-thinking stage: if the task is complex, also record a plan (todo_write). **Complete when: you understand the task (assumptions stated, or key ambiguities answered) — and, if complex, a plan is recorded. No alignment, no advancement.** → Done? Understood (stated assumption / question answered / plan recorded) → next stage.',
-  'Phase: planning. Unlocked: todo_write/exit_plan_mode + memory review (search/open). Do this stage properly: design the approach, cover edge cases, define what "done" means, and decide acceptance criteria — not just list steps. **Attention reclamation (v1.26): assetize your context — keep the task goal + the current decision + the live evidence in the attention window; sink settled exploration/details into memory (engram_store) instead of holding them all; let stale, superseded, or resolved threads truly drop (fresh context recovers attention). Do not hold "everything might be useful" in mind — that is attention leakage, not diligence.** **Isolation & parallel (pillar 4): when two independent concerns are polluting one thread, or a sub-problem is eating the mainline budget, push it into a subagent / workflow (independent context) instead of keeping it in the same stream — a focused subagent holds its own attention so your mainline stays on the critical path.** **Complete when: the plan is thorough enough that the design is decision-complete (what to build, how it fits, what success looks like), recorded via todo_write or presented via exit_plan_mode.** Only this lets you enter development. Note: a completion signal (todo_write / exit_plan_mode) AUTO-advances to the next phase — do NOT call phase_advance after it, or you will skip a phase. → Done? Plan is decision-complete and locked (todo_write / exit_plan_mode) → develop (auto).',
-  'Phase: development. Unlocked: write/edit/str_replace_editor + memory write (store/link). Re-read before re-edit (editor enforces fresh read); write/edit results carry FULL before/after text — take path/operation, inspect with grep/read. Do this stage properly: make the artifact real, self-check it against the plan and the acceptance criteria, and do not declare it done until it actually passes its own check. **Avoid local-optima (v1.22): keep the WHOLE artifact working while you iterate. If you find yourself re-fighting the same detail for several rounds with no convergence (e.g. a finite-difference sign, a conservation drift), step back: (1) is this detail blocking the overall deliverable, or is it polish? (2) preserve a working version; iterate on the detail in parallel, not by stalling the whole. (3) if a detail resists, finish the rest and re-attack it fresh — do not let one stubborn sub-problem stall the deliverable.** **Complete when: the artifact exists and passes its self-check — then enter verification via delivery_check (completion signal) or phase_advance.** → Done? Self-check passes → delivery_check → verification.',
-  'Phase: verification → delivery gate. Unlocked: pwsh/bash/read_image/jobs + delivery_check. Windows: bash = Git Bash (first-class), pwsh for PowerShell; Git Bash may need the one-shot sandbox escalation (approval=never: if denied, report it — never bypass). Page verify with your OWN tools: run a headless browser/playwright via bash (or install one), screenshot + read_image each shot (reviewed:true) to visually confirm. **On verification failure, hold a quick hypothesis-audit (guidance, not a hard block): before touching the implementation, name in one line (a) which assumption you are now re-checking, (b) what NEW evidence you just gained — this turns "doubt the hypothesis" from a prompt into a habit. If the code is actually correct, say so and move on (do not manufacture a bug to justify rework).** Then check gates/evidence. Do this stage properly: verify the real artifact, not a summary of it — check evidence, look for defects, review the visuals honestly. **Gate: delivery_check must PASS — evidence manifest required; missing evidence/unreviewed visuals = FAIL.**',
+  'Phase: understanding. Unlocked: this stage only — read/glob/grep/web_search/ask_user_question + memory recall/verify/respond. Ground first: recall → verify → read/ask. Think broadly — do not settle on the first reading. Break the request into dimensions and decide each ambiguity by impact: one reasonable reading → state the assumption in one sentence and continue; two+ readings that materially change the result → ONE ask_user_question per ambiguity (concrete options). Do not under-ask (assume everything) nor over-ask (interrogate trivia). Complex task → record a plan (todo_write). **Complete when the task is understood (assumptions stated / key ambiguities answered) and, if complex, a plan is recorded. No alignment, no advancement.** → Done? Understood → next stage.',
+  'Phase: planning. Unlocked: todo_write/exit_plan_mode + memory review (search/open). Design the approach: cover edge cases, define "done" and acceptance criteria — not just steps. **Attention (v1.26): hold task goal + current decision + live evidence; sink settled detail into memory (engram_store); let stale/superseded threads drop — attention leakage is not diligence.** **Isolation (v1.27): an independent concern polluting this thread → split it into its own todo now; subagent/workflow 独立上下文在验证阶段才解锁，届时用它隔离，当前阶段先把关注点拆成条目。** **Complete when the plan is decision-complete and locked (todo_write / exit_plan_mode). Only this lets you enter development. Completion signal AUTO-advances — do NOT call phase_advance after it (would skip a phase).** → Done? Plan locked → develop (auto).',
+  'Phase: development. Unlocked: write/edit/str_replace_editor + memory write (store/link). Re-read before re-edit; write/edit results carry FULL before/after text — take only path/operation, inspect with grep/read. Make the artifact real and self-check against the plan + acceptance criteria; do not declare done until it passes its own check. **Avoid local-optima (v1.22): keep the WHOLE artifact working — a stubborn detail is polish unless it blocks the deliverable; finish the rest and re-attack it fresh.** **Complete when the artifact exists and passes its self-check → enter verification via delivery_check (completion signal) or phase_advance.** → Done? Self-check passes → delivery_check → verification.',
+  'Phase: verification → delivery gate. Unlocked: pwsh/bash/read_image/jobs + delivery_check. Windows: bash = Git Bash (first-class), pwsh for PowerShell; one-shot sandbox escalation denied → report, never bypass. Page verify with YOUR OWN tools: bash headless Chrome/playwright screenshot + read_image each shot (reviewed:true). **On failure: one-line hypothesis audit — (a) which assumption are you re-checking, (b) what NEW evidence did you gain; if the code is correct, say so and move on (do not manufacture a bug).** **Gate: delivery_check must PASS — evidence manifest required; missing evidence/unreviewed visuals = FAIL.** → Done? Gate passed → delivered.',
 ]
 
 /** 阶段文本（we-form——you-form 是 let me 吸引子）。
@@ -434,10 +434,7 @@ export async function deliveryCheck(ctx, args) {
   // v1.23（方案A·大道至简）：delivery_check 不再自跑 headless smoke（此前复用 dev_page_check/pageCheckRun，反复出bug）。
   // 页面交付物的视觉验证交给**模型用 bash 自测**（playwright/headless Chrome 截图 + read_image 视觉确认），
   // 并在 evidence 里给 visual proof（kind=image, reviewed:true）。delivery_check 校验 evidence 门禁，而非自已渲染。
-  const requireSmoke = args?.requireSmoke !== false
-  if (args?.url && requireSmoke) {
-    checks.push({ name: 'page-verify', pass: false, detail: 'visual verify the page with bash (headless Chrome/playwright screenshot) + read_image (reviewed:true) into evidence — delivery_check gates the evidence, not a built-in browser' })
-  }
+  /* v1.29：删除旧“url+requireSmoke→无条件 page-verify FAIL”陷阱——视觉证据要求已由 delivery-evidence（reviewed:true）覆盖。
   /* 证据门禁（正式交付契约——v1.14 规范化：schema 写清进工具描述，不再让模型读源码）：
    * evidence.items[] 每项: { label, kind ∈ file|page|image|run|test|text|external|numeric, target?（file/page/image/test 必填路径）,
    *   result?（run/text 必填文本）, reviewed?: true（page/image 视觉类必须人工复核过）}
@@ -639,7 +636,7 @@ export function apply(ctx, config) {
 
     if (!promoted) {
       // 首轮：无 restrict + 工具面只留 phase_begin（纯 RL 条件 = 稳定 we）
-      return { ...assembled, sections: baseSections, contexts: [], tools: assembled.tools.filter((tool) => tool.name === 'phase_begin') }
+      return { ...assembled, sections: baseSections, tools: assembled.tools.filter((tool) => tool.name === 'phase_begin') } // v1.29: 保留他方 runtime contexts
     }
 
     // promoted：官方 sections 回流（persona 保持 RL 句）+ 引导带宽控 + 阶段声明 + 常驻段
@@ -661,10 +658,10 @@ export function apply(ctx, config) {
     if (available.has('run_code')) {
       const staged = buildStagedSdk(sections, stage)
       if (staged) {
-        return { ...assembled, sections: sections.map((s) => (s.name === 'tools:sdk' ? staged : s)), contexts: [] }
+        return { ...assembled, sections: sections.map((s) => (s.name === 'tools:sdk' ? staged : s)) }
       }
     }
-    return { ...assembled, sections, contexts: [] }
+    return { ...assembled, sections }
   })
 
   // ── 自主路由（pre-step）：调用下一档工具 → 自动推进阶段 ──────────────────
@@ -676,7 +673,7 @@ export function apply(ctx, config) {
     const sid = agent.session.id
     const st = (ensureStage()[sid] ??= { stage: 0, guided: false })
     const stageAt = st.stageAtTime ?? 0
-    const toolCalls = (agent.session.events || []).filter((e) => (e.time === undefined || e.time >= stageAt) && (e.type === 'tool/call' || e.type === 'tool/code-dispatch')).map((e) => ({ name: e.data?.name || e.data?.toolName || '', args: toolArgs(e.data) }))
+    const toolCalls = (agent.session.events || []).filter((e) => (e.time === undefined || e.time >= stageAt) && (e.type === 'tool/call' || e.type === 'tool/code-dispatch')).map((e) => ({ name: e.data?.name || e.data?.toolName || '', args: toolArgs(e.data), time: e.time }))
     // v1.17.2：被拒的锁定工具调用（如阶段 0 调 bash → unknown tool）不算行为信号——
     // 只有当前阶段真实可调（view.visible）的工具调用才触发直达推进。
     let advanceCalls = toolCalls
@@ -688,7 +685,10 @@ export function apply(ctx, config) {
     const nextStage = autoAdvance(st.stage, advanceCalls, text)
     if (nextStage > st.stage) {
       st.stage = nextStage
-      st.stageAtTime = Date.now()
+      // v1.29：阶段边界 = 已消费事件最大时间 +1（确定性）——事件时间严格递增的宿主语义不变；
+      // 测试可注入显式递增时间戳，不再受同毫秒墙钟碰撞影响（此前 Date.now() 与事件同 ms 时会重算已消费信号）。
+      const consumedMax = Math.max(0, ...toolCalls.map((c) => (Number.isFinite(c.time) ? Number(c.time) : 0)))
+      st.stageAtTime = consumedMax > 0 ? consumedMax + 1 : Date.now()
       st.lastAdvance = { at: Date.now(), reason: 'auto:' + advanceCalls.map((c) => c.name).filter(Boolean).join(',') }
       saveStageState()
       applyStageRestrict(agent, nextStage)
@@ -902,11 +902,8 @@ export function apply(ctx, config) {
     description: DESC.deliveryCheck,
     parameters: {
       file: { type: 'string', required: true, description: '交付物文件路径（绝对路径或工作区相对路径）' },
-      url: { type: 'string', description: '页面交付物必传：http(s):// / file:// / 裸路径（自动编码）——省略时 headless-smoke 判 FAIL（requireSmoke: false 才可跳过，仅限脚本/文档类非页面产物）' },
-      requireSmoke: { type: 'boolean', description: '默认 true：页面产物必须跑 headless smoke（避免"省略 url 即绕过"）。非页面产物传 false' },
-      timeoutMs: { type: 'number', description: 'smoke 硬超时毫秒（默认 20000）' },
-      virtualTimeMs: { type: 'number', description: 'smoke 虚拟时间预算（默认 8000）' },
-      retry: { type: 'boolean', description: 'smoke 失败时自动重试一次（默认 true，降分辨率+双倍虚拟时间）' },
+      url: { type: 'string', description: '页面交付物标记：http(s):// / file:// / 裸路径。传了即按页面门禁——delivery-evidence 须含 ≥1 项 reviewed:true 视觉证据（kind ∈ page|image|external，见 evidence）；省略 = 非页面门禁（文件/证据门禁仍生效）。' },
+      
       evidence: { type: 'object', description: '通用证据清单。结构（唯一权威）：{ items: [{ label, kind ∈ file|page|image|run|test|text|external|numeric, target?（file/page/image/test 必填路径）, result?（run/text/external 必填文本）, reviewed?: true（page/image 视觉类必须人工复核过） }] }。页面交付物要求至少一项 reviewed:true 的视觉证据；为空则 delivery-evidence 判 FAIL。', properties: {
         items: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
           kind: { type: 'string', enum: ['file','page','image','run','test','text','external','numeric'] },
@@ -1043,9 +1040,7 @@ export function apply(ctx, config) {
       description: DESC.deliveryCheck,
       parameters: {
         file: { type: 'string', required: true, description: '交付物文件路径' },
-        url: { type: 'string', description: '可选页面地址（自动编码）' },
-        timeoutMs: { type: 'number' }, virtualTimeMs: { type: 'number' }, retry: { type: 'boolean' },
-        requireSmoke: { type: 'boolean', description: '默认 true：页面产物必须 smoke（省略 url 即 FAIL，不再可绕过）' },
+        url: { type: 'string', description: '页面交付物标记：传了即要求 evidence 含 ≥1 项 reviewed:true 视觉证据（页面门禁）' },
         evidence: { type: 'object', description: '证据清单（结构见 tools_help）：{ items: [{ label, kind ∈ file|page|image|run|test|text|external|numeric, target?, result?, reviewed? }] }——页面类要求至少一项 reviewed:true 视觉证据', properties: {
           items: { type: 'array', items: { type: 'object', additionalProperties: false, properties: {
             kind: { type: 'string', enum: ['file','page','image','run','test','text','external','numeric'] },

--- a/preset/router.integration.test.mjs
+++ b/preset/router.integration.test.mjs
@@ -80,7 +80,7 @@ function baseAssembled() {
   return {
     sections: SECTIONS.map((s) => ({ ...s })),
     tools: TOOLS.map((t) => ({ ...t })),
-    contexts: [],
+    contexts: [{ name: 'harness-foreign', order: 200, text: 'foreign runtime fact (v1.29 preserved)' }],
     variables: { provider: 'deepseek-official', model: 'deepseek-v4-flash' },
   }
 }
@@ -119,7 +119,7 @@ test('first request: RL persona + phase_begin as the only first-turn tool (v0.9)
   assert.match(assembled.sections.find((s) => s.name === 'router-persona').text, /^You are a helpful software engineer assistant\./)
   assert.ok(!assembled.sections.some((s) => s.name === 'router-stage'), 'stage section appears only after phase_begin/promotion')
   assert.deepEqual(assembled.tools.map((t) => t.name), ['phase_begin'])
-  assert.deepEqual(assembled.contexts, [])
+  assert.deepEqual(assembled.contexts, baseAssembled().contexts, 'v1.29: router preserves foreign runtime contexts on the first turn')
   // no injection in the harness (no inbox): the decision stays on the real message
   assert.deepEqual(decision.messages.map((m) => m.id), ['m1'])
 })
@@ -191,7 +191,7 @@ test('standard preset: after the first tool/call the router keeps the full surfa
   assert.match(stageTextSec.text, /Task: 从零开发一个马里奥网页游戏/, 'stage text echoes the real user task (guiding, not gating)')
   assert.ok(assembled.sections.some((s) => s.name === 'router-decl'), 'progressive declaration persists after promotion')
   assert.ok(assembled.sections.some((s) => s.name === 'router-proactivity'), 'pressure guide persists after promotion')
-  assert.deepEqual(assembled.contexts, [])
+  assert.deepEqual(assembled.contexts, baseAssembled().contexts, 'v1.29: router preserves foreign runtime contexts after promotion')
   assert.ok(assembled.tools.length === TOOLS.length, 'full tool catalog exposed')
   assert.match(assembled.sections.find((s) => s.name === 'persona').text, /^You are a helpful software engineer assistant\.$/)
 })
@@ -352,7 +352,7 @@ test('spec preset (routerMode: standard): RL first turn, then full assembly retu
   // RL-interface first turn
   assert.deepEqual(assembled.sections.map((s) => s.name), ['plan-mode', 'router-persona'])
   assert.deepEqual(assembled.tools.map((t) => t.name), ['pwsh', 'str_replace_editor'])
-  assert.deepEqual(assembled.contexts, [])
+  assert.deepEqual(assembled.contexts, baseAssembled().contexts, 'v1.29: spec first turn preserves foreign runtime contexts')
 
   // promoted: the router stops touching the assembly (full sections restored)
   session.events.push({ type: 'tool/call', data: {} })
@@ -439,22 +439,22 @@ test('v1.19: completion signals drive the phase ladder; tool names do not', asyn
   const agent = makeStageAgent(session, appends)
   h.agentRef.current = agent
   // todo_write → planning
-  session.events.push({ type: 'tool/call', data: { name: 'todo_write', arguments: '{}' }, time: Date.now() })
+  session.events.push({ type: 'tool/call', data: { name: 'todo_write', arguments: '{}' }, time: 1001 })
   await h.preStep({ agent, messages: [userMessage('v1', '先看计划')], turn: 1, step: 1 })
   let disk = JSON.parse(readFileSync(file, 'utf8'))
   assert.equal(disk.sessions[session.id].stage, 1, 'todo_write completes alignment → planning')
   // 工具名（哪怕下一档开发工具）不再跳级
-  session.events.push({ type: 'tool/call', data: { name: 'str_replace_editor', arguments: JSON.stringify({ command: 'create', path: 'x.txt', file_text: 'x' }) }, time: Date.now() })
+  session.events.push({ type: 'tool/call', data: { name: 'str_replace_editor', arguments: JSON.stringify({ command: 'create', path: 'x.txt', file_text: 'x' }) }, time: 1002 })
   await h.preStep({ agent, messages: [userMessage('v2', '开始写')], turn: 2, step: 1 })
   disk = JSON.parse(readFileSync(file, 'utf8'))
   assert.equal(disk.sessions[session.id].stage, 1, 'using a dev tool does not skip planning')
   // 计划锁定（todo_write again）→ development
-  session.events.push({ type: 'tool/call', data: { name: 'todo_write', arguments: JSON.stringify({ todos: [] }) }, time: Date.now() })
+  session.events.push({ type: 'tool/call', data: { name: 'todo_write', arguments: JSON.stringify({ todos: [] }) }, time: 1003 })
   await h.preStep({ agent, messages: [userMessage('v3', '计划锁定')], turn: 3, step: 1 })
   disk = JSON.parse(readFileSync(file, 'utf8'))
   assert.equal(disk.sessions[session.id].stage, 2, 'locked plan completes planning → development')
   // delivery_check → verification
-  session.events.push({ type: 'tool/call', data: { name: 'delivery_check' }, time: Date.now() })
+  session.events.push({ type: 'tool/call', data: { name: 'delivery_check' }, time: 1004 })
   await h.preStep({ agent, messages: [userMessage('v4', '交付')], turn: 4, step: 1 })
   disk = JSON.parse(readFileSync(file, 'utf8'))
   assert.equal(disk.sessions[session.id].stage, 3, 'delivery intent completes development → verification')

--- a/preset/router.test.mjs
+++ b/preset/router.test.mjs
@@ -225,31 +225,44 @@ test('paramHint: 参数名+类型速览消灭猜参数摩擦 (v1.4 → v1.5 带�
   assert.match(paramHint(() => ({})), /tools_help/)
   assert.equal(paramHint(undefined), 'no params')
 })
-test('deliveryCheck: 交付 gate 检查清单（v1.11 → v1.14 requireSmoke+evidence）', async () => {
+test('deliveryCheck: 交付 gate 证据门禁（v1.29：schema=执行对齐，无内置 smoke，url=页面门禁标记）', async () => {
   // 缺失路径 → FAIL + 证据
   const nofile = await deliveryCheck({ get: () => undefined }, { file: 'Z:\\\\no-such-file-xyz.html' })
   assert.equal(nofile.ok, false)
   assert.ok(nofile.checks.some((c) => c.name === 'file-exists' && !c.pass))
-  // 临时有效文件：无 url + 无 evidence → smoke/evidence FAIL（v1.14 不再可绕过）
+  // 临时有效文件：无 evidence → 证据 FAIL；且无 page-verify 判定（v1.29 不再内置 smoke）
   const tmp = join(process.cwd(), '.t-delivery-probe.html')
   writeFileSync(tmp, '<!doctype html><html><head><title>OK</title></head><body>x</body></html>', 'utf8')
   try {
-    const noSmoke = await deliveryCheck({ get: () => undefined }, { file: tmp })
-    assert.equal(noSmoke.ok, false)
-    assert.ok(noSmoke.checks.some((c) => c.name === 'page-verify' && !c.pass || (c.name === 'delivery-evidence' && !c.pass)), 'page verify required (v1.23: model self-tests via bash, gate on evidence)')
-    assert.ok(noSmoke.checks.some((c) => c.name === 'delivery-evidence' && !c.pass), 'evidence required')
-    // 非页面产物显式关 smoke + 给 evidence → PASS
+    const noEv = await deliveryCheck({ get: () => undefined }, { file: tmp })
+    assert.equal(noEv.ok, false)
+    assert.ok(noEv.checks.some((c) => c.name === 'delivery-evidence' && !c.pass), 'evidence required')
+    assert.ok(!noEv.checks.some((c) => c.name === 'page-verify'), 'v1.29: delivery_check 不内置 smoke（schema 与执行一致）')
+    // 非页面产物：file evidence → PASS
     const okr = await deliveryCheck({ get: () => undefined }, {
-      file: tmp, requireSmoke: false,
+      file: tmp,
       evidence: { items: [{ label: 'file', kind: 'file', target: tmp }] },
     })
     assert.equal(okr.ok, true)
+    // 页面交付物：url + reviewed 视觉证据 → PASS
+    const pageOk = await deliveryCheck({ get: () => undefined }, {
+      file: tmp, url: 'http://localhost:3000/x.html',
+      evidence: { items: [{ label: 'shot', kind: 'image', target: tmp, reviewed: true }] },
+    })
+    assert.equal(pageOk.ok, true)
+    // 页面交付物：url 但无 reviewed 视觉证据 → FAIL
+    const pageBad = await deliveryCheck({ get: () => undefined }, {
+      file: tmp, url: 'http://localhost:3000/x.html',
+      evidence: { items: [{ label: 'file', kind: 'file', target: tmp }] },
+    })
+    assert.equal(pageBad.ok, false)
+    assert.ok(pageBad.checks.some((c) => c.name === 'delivery-evidence' && !c.pass), 'page deliverable needs reviewed visual evidence')
   } finally { rmSync(tmp, { force: true }) }
   // 非法 UTF-8 → encoding FAIL
   const bad = join(process.cwd(), '.t-bad.html')
   writeFileSync(bad, Buffer.from([0xff, 0xfe, 0x00, 0x41]), 'utf8')
   try {
-    const badr = await deliveryCheck({ get: () => undefined }, { file: bad, requireSmoke: false, evidence: { items: [{ label: 'f', kind: 'file', target: bad }] } })
+    const badr = await deliveryCheck({ get: () => undefined }, { file: bad, evidence: { items: [{ label: 'f', kind: 'file', target: bad }] } })
     assert.equal(badr.ok, false)
     assert.ok(badr.checks.some((c) => c.name === 'encoding-utf8' && !c.pass))
   } finally { rmSync(bad, { force: true }) }
@@ -273,7 +286,7 @@ test('v1.16: muteAwareList/isMemoryTool + external evidence', async () => {
   writeFileSync(tmp, 'x', 'utf8')
   try {
     const okr = await deliveryCheck({ get: () => undefined }, {
-      file: tmp, requireSmoke: false,
+      file: tmp,
       evidence: { items: [{ label: 'pw-screenshot', kind: 'external', target: tmp, reviewed: true }] },
     })
     assert.equal(okr.ok, true)


### PR DESCRIPTION
## What & Why

router-standard v1.29 / super-injector v0.3.4 的成套对齐（双技能：context-engineering + system-prompt-engineering），并首立镜像同步策略：

1. **同步策略（source of truth）**：上游独立仓库 = 发布源（PR 演进）；本仓库 injector/、preset/ = 安装镜像（整体复制，禁止双向人工演进）。
2. **随带镜像同步**：router-standard v1.29.0（delivery_check schema=执行一致、保留他方 runtime contexts、阶段边界确定性、指南声明式化）+ super-injector v0.3.4（能力声明 section 化、dev_* 清理作用域收窄）同步进 `preset/`、`injector/`。
3. **版本矩阵/能力描述对齐**：README 更新为当前主线（渐进披露 + 证据门禁），persona 路由实验线标注为历史档案。

## 验证

- 捆绑测试：preset/router.test.mjs + preset/router.integration.test.mjs → **50/50 PASS**（含 deliveryCheck 新契约、contexts 保留、确定性阶段边界）。
- 行为面（装进 3081 的真实渲染）由 A2A 测试节点执行。

## 无未决项（作者视角）

- `preset/` 内 router-standard 与独立仓库 main 的完整对齐（本次仅带 v1.29 变更文件）按同步策略在合并后执行；已注明 sync sha。
