### PR TITLE
fix: phase ladder double-advances within one millisecond (#73)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -35,6 +35,9 @@ Copy-Item -Recurse .\preset\router-spec $target
 # Step 3: restart DSH → pick Router Standard / Router Spec in a new session
 ```
 
+> `preset/router-react` (v17) also ships in this repo but is NOT installed by `install.ps1`.
+> Copy it the same way as the other two if you want it.
+
 > Do NOT copy the `preset` directory as a whole — the extra nesting hides the
 > presets from DSH discovery.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Copy-Item -Recurse .\preset\router-spec $target
 # 步骤 3：重启 DSH → 新会话选择 Router Standard / Router Spec (experimental)
 ```
 
+> 仓库另附 `preset/router-react`（v17），`install.ps1` 不安装；需要时按同样方式单独复制。
+
 > 注意：不要复制 `preset` 整目录（会多套一层，DSH 发现不了预设）。
 
 ## 组件

--- a/injector/README.md
+++ b/injector/README.md
@@ -248,6 +248,9 @@ minimal 99/96 vs standard 91 vs 两阶段 98/99、触发机制微探针、轨迹
 
 ## 踩坑记录
 
+- **本仓库源码开发：`npm i` 必须带 `--legacy-peer-deps`**：peerDependencies（`@deepseek-ai/dsh-tools` 等）由
+  DSH 宿主在 `dsh plugin add` 时提供，npm 却会自动安装 peer 并撞上未发布的 `@deepseek-ai/dsh-type-meta`（404）——
+  用 `npm i --legacy-peer-deps` 跳过；`prepare` 钩子照常构建 `lib/`。`tsc --noEmit` 在无 peer 时报缺模块属正常；
 - **插件包必须自带依赖链接**：`lib/` 里 `import '@deepseek-ai/dsh-tools'` 等从包自身 `node_modules` 解析——照 build.sh 建 junction 到 checkout 包（如 `node_modules/@deepseek-ai/dsh-tools → <checkout>/packages/core/tools`）；
 - **client bundle 需单独构建**：host 侧 `bash scripts/build.sh`（tsc），client 侧 `npm run build:client`（tsdown，产物 `lib/client.js`）——注入插件要出 UI 必须两步都构建；
 - **失败 import 会毒化重试**：loadCache 残留残缺 job 导致同名重载复用失败态——注入前 `purgeCache` 清理；

--- a/preset/package.json
+++ b/preset/package.json
@@ -28,8 +28,7 @@
     "router.integration.test.mjs"
   ],
   "scripts": {
-    "test": "node --test router.test.mjs router.integration.test.mjs",
-    "probe": "node probe/matrix.mjs"
+    "test": "node --test router.test.mjs router.integration.test.mjs"
   },
   "engines": { "node": ">=22" }
 }

--- a/preset/router-standard/router-bootstrap-v34.mjs
+++ b/preset/router-standard/router-bootstrap-v34.mjs
@@ -542,7 +542,7 @@ function loadStageState() {
       const out = {}
       for (const [sid, st] of Object.entries(parsed.sessions)) {
         const stage = Number(st?.stage)
-        if (Number.isInteger(stage) && stage >= 0 && stage <= 3) out[sid] = { stage, guided: st?.guided === true, ...(Number.isFinite(st?.stageAtTime) ? { stageAtTime: st.stageAtTime } : {}), ...(st?.lastAdvance && typeof st.lastAdvance === 'object' ? { lastAdvance: { at: Number.isFinite(st.lastAdvance.at) ? st.lastAdvance.at : 0, reason: st.lastAdvance.reason ?? null } } : {}) }
+        if (Number.isInteger(stage) && stage >= 0 && stage <= 3) out[sid] = { stage, guided: st?.guided === true, ...(Number.isFinite(st?.stageAtTime) ? { stageAtTime: st.stageAtTime } : {}), ...(Number.isInteger(st?.consumed) && st.consumed >= 0 ? { consumed: st.consumed } : {}), ...(st?.lastAdvance && typeof st.lastAdvance === 'object' ? { lastAdvance: { at: Number.isFinite(st.lastAdvance.at) ? st.lastAdvance.at : 0, reason: st.lastAdvance.reason ?? null } } : {}) }
       }
       return out
     }
@@ -554,6 +554,14 @@ function saveStageState() {
     mkdirSync(join(stageFile(), '..'), { recursive: true })
     writeFileSync(stageFile(), JSON.stringify({ version: 2, savedAt: new Date().toISOString(), sessions: ensureStage() }, null, 2), 'utf8')
   } catch (e) { console.error('[router-bootstrap] saveStageState failed:', e) }
+}
+
+/** 阶段推进后标记「已消费」的事件下标：毫秒时间戳分辨率不足，同一毫秒内的调用会被
+ *  下一步重复计入并再次跳级（v0.3.0 缺陷）。事件下标是身份，不是时钟。 */
+function markStageConsumed(st, session) {
+  st.stageAtTime = Date.now()
+  const events = session?.events
+  if (Array.isArray(events)) st.consumed = events.length
 }
 
 /** restrict 交集修复：per-session disposer（释放旧再设新）。 */
@@ -675,8 +683,13 @@ export function apply(ctx, config) {
     const text = userMsg ? extractText(userMsg) : ''
     const sid = agent.session.id
     const st = (ensureStage()[sid] ??= { stage: 0, guided: false })
+    const events = agent.session.events || []
     const stageAt = st.stageAtTime ?? 0
-    const toolCalls = (agent.session.events || []).filter((e) => (e.time === undefined || e.time >= stageAt) && (e.type === 'tool/call' || e.type === 'tool/code-dispatch')).map((e) => ({ name: e.data?.name || e.data?.toolName || '', args: toolArgs(e.data) }))
+    // consumed = 已推进过的事件下标（身份水位）；旧状态无此字段时回退到时间过滤。
+    const fresh = Number.isInteger(st.consumed)
+      ? events.slice(st.consumed)
+      : events.filter((e) => e.time === undefined || e.time >= stageAt)
+    const toolCalls = fresh.filter((e) => e.type === 'tool/call' || e.type === 'tool/code-dispatch').map((e) => ({ name: e.data?.name || e.data?.toolName || '', args: toolArgs(e.data) }))
     // v1.17.2：被拒的锁定工具调用（如阶段 0 调 bash → unknown tool）不算行为信号——
     // 只有当前阶段真实可调（view.visible）的工具调用才触发直达推进。
     let advanceCalls = toolCalls
@@ -688,7 +701,7 @@ export function apply(ctx, config) {
     const nextStage = autoAdvance(st.stage, advanceCalls, text)
     if (nextStage > st.stage) {
       st.stage = nextStage
-      st.stageAtTime = Date.now()
+      markStageConsumed(st, agent.session)
       st.lastAdvance = { at: Date.now(), reason: 'auto:' + advanceCalls.map((c) => c.name).filter(Boolean).join(',') }
       saveStageState()
       applyStageRestrict(agent, nextStage)
@@ -800,7 +813,7 @@ export function apply(ctx, config) {
       const state = ensureStage()
       state[sid] = state[sid] ?? { stage: 0, guided: false }
       state[sid].stage = next
-      state[sid].stageAtTime = Date.now()
+      markStageConsumed(state[sid], session)
       state[sid].lastAdvance = { at: Date.now(), reason: args?.reason ? String(args.reason) : null }
       saveStageState()
       applyStageRestrict(currentAgent(), next)
@@ -1019,7 +1032,7 @@ export function apply(ctx, config) {
         const st = (ensureStage()[sid] ??= { stage: 0, guided: false })
         if (st.stage >= STAGES.length - 1) return 'already at the last stage (' + STAGES[st.stage].name + '); full catalog is open'
         st.stage += 1
-        st.stageAtTime = Date.now()
+        markStageConsumed(st, agent?.session)
         st.lastAdvance = { at: Date.now(), reason: args?.reason ? String(args.reason) : null }
         saveStageState()
         applyStageRestrict(agent, st.stage)
@@ -1165,7 +1178,7 @@ export function apply(ctx, config) {
       execute: async () => {
         const st = (ensureStage()[sid] ??= { stage: 0, guided: false })
         st.stage = 0
-        st.stageAtTime = Date.now()
+        markStageConsumed(st, agent?.session)
         saveStageState()
         applyStageRestrict(agent, 0)
         const ownT = toolsSvc?.layers?.scoped?.get?.(agent)?.tools


### PR DESCRIPTION
Fixes #73. Documents #74.

## 1. Phase ladder double-advance (#73) — the only behavior change

`router-bootstrap-v34.mjs` decided which tool calls were "already consumed" by wall clock:

```js
const stageAt = st.stageAtTime ?? 0
const toolCalls = events.filter((e) => (e.time === undefined || e.time >= stageAt) && ...)
```

`st.stageAtTime` is `Date.now()` at the advance, and the event that caused it carries the same
millisecond — so `>=` re-counts it next step and one `todo_write` buys two stages. That is exactly
the "tool names skip stages" behavior the v1.19 comment above `autoAdvance` rules out.

Flipping to `>` does not fix it; it moves the failure to the next assert. Timestamps are the wrong
key at this resolution — event identity is the right one.

- `markStageConsumed(st, session)` sets `st.stageAtTime` **and** `st.consumed = session.events.length`
- called from all four stage mutations: auto-advance, `phase_advance`, the meta-shim advance, `dev_reset_experience`
- pre-step scans `events.slice(st.consumed)`
- entries without `consumed` (existing `stages.json`) fall back to the old time filter — no migration
- `consumed` added to the `loadStageState` whitelist so it survives restart
- `stageAtTime` retained; `dev_router_status` still reads `lastAdvance`

Replay-idempotence is preserved, and now genuinely clock-independent — which is what the
"resume-safe phase routing (v0.8)" comment on `advanceStage` promises.

## 2. injector README: `npm i --legacy-peer-deps` (#74)

One 踩坑记录 entry: bare `npm i` 404s on the unpublished `@deepseek-ai/dsh-type-meta` because npm
auto-installs peers the DSH host is meant to provide. Notes that `tsc --noEmit` errors without peers
are expected.

## 3. Truth-up

- `preset/package.json`: dropped `"probe": "node probe/matrix.mjs"` — `preset/probe/` contains only
  `README.md` and `cot-lexicon.md`; the script cannot run.
- Both READMEs: `preset/router-react` (v17) ships in the repo but `install.ps1` installs only
  `router-standard` / `router-spec`. One line saying so.

## Verification

```
node --test router.test.mjs router.integration.test.mjs
ℹ tests 50   ℹ pass 50   ℹ fail 0      (3 consecutive full runs)

node router-standard/router-bootstrap-v34.selftest.mjs
SELFTEST PASS
```

Before this branch: 49/50, deterministic. No test was modified.
