### PR TITLE
fix(injector): unpin unpublished dsh-type-meta so npm ci works (#74)

### DIFF
--- a/injector/INSTALL.md
+++ b/injector/INSTALL.md
@@ -59,7 +59,25 @@ dsh plugin --profile web add ~/dsh-super-injector
 dsh plugin --profile web add github:yjh051108/dsh-super-injector
 ```
 
-重启 web 后同上验证。（git 安装只取源码，需要本机有构建环境：bash + node + npm + DSH checkout 或 `DSH_CHECKOUT` 环境变量。）
+重启 web 后同上验证。（git 安装只取源码，构建由已提交的 `prepare` 脚本自动完成——
+`npm`/`pnpm` 抓取后即运行，产出自包含的 `lib/`，无需 DSH checkout。）
+
+自己从源码构建（例如改过 `src/` 之后）：
+
+```bash
+# 1. 安装依赖。peerDependencies 由 DSH 宿主提供，npm 却会自动装 peer 并撞上
+#    未发布的 @deepseek-ai/dsh-type-meta（E404）——用 --legacy-peer-deps 跳过。
+npm install --legacy-peer-deps --no-audit --no-fund
+
+# 2. 类型检查 + 声明产出。cordis/schemastery 必须解析到 @deepseek-ai 的分叉版
+#    （4.0.1 / 3.18.1）：公共 registry 的 cordis d.ts 在 NodeNext 下是坏的，
+#    而打包后的 app bundle 又把分叉版 d.ts 剥掉了。把分叉包复制进
+#    node_modules/@deepseek-ai/ 并链接（之后任何 npm install 都会再次剪掉，需重链）。
+./node_modules/.bin/tsc -p tsconfig.json
+
+# 3. 打包 host + client（lib/ 已存在时 prepare.mjs 会跳过——先 rm -rf lib 强制重建）
+./node_modules/.bin/tsdown --config tsdown.config.ts
+```
 
 ---
 

--- a/injector/package-lock.json
+++ b/injector/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@dsh-external/dsh-super-injector",
-  "version": "0.3.1",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dsh-external/dsh-super-injector",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "license": "BSD-3-Clause",
       "devDependencies": {
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
         "@types/node": "^24.13.3",
         "tsdown": "^0.22.14",
-        "typescript": "^5.9.0"
+        "typescript": "^5.9.3"
       },
       "peerDependencies": {
         "@deepseek-ai/dsh-tools": ">=0.0.1-rc <2",
@@ -20,21 +21,19 @@
       }
     },
     "node_modules/@deepseek-ai/cordis": {
-      "version": "4.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cordis/-/cordis-4.0.1-rc.1.tgz",
-      "integrity": "sha512-S6gVP4ZwkNy2bsPdz2Wc4wII69uRs98e5OJ1Xsd8idxxXTIgAG7eMF8CqVz6fPxves79htnHlP55ZkOgTfwZTQ==",
+      "version": "4.0.1",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2-rc.1",
+        "@deepseek-ai/cosmokit": "^1.8.2",
         "@standard-schema/spec": "^1.1.0"
       },
       "bin": {
         "cordis": "bin.js"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis-plugin-include": "^1.0.5-rc.1",
-        "@deepseek-ai/cordis-plugin-loader": "^1.0.1-rc.1"
+        "@deepseek-ai/cordis-plugin-include": "^1.0.6",
+        "@deepseek-ai/cordis-plugin-loader": "^1.0.2"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/cordis-plugin-include": {
@@ -45,56 +44,62 @@
         }
       }
     },
-    "node_modules/@deepseek-ai/cosmokit": {
-      "version": "1.8.2-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/cosmokit/-/cosmokit-1.8.2-rc.1.tgz",
-      "integrity": "sha512-4GQw84Y80yipE1dmLO20WVAVIdC3s1SfHwsO39iYcEkP8rN4FOJK4cxo0RENYVsdWhNEkRIze+ynAJY/EW1Ukg==",
+    "node_modules/@deepseek-ai/cordis-plugin-loader": {
+      "version": "1.0.2",
+      "devOptional": true,
       "license": "MIT",
-      "peer": true
+      "dependencies": {
+        "@deepseek-ai/cosmokit": "^1.8.2"
+      },
+      "peerDependencies": {
+        "@deepseek-ai/cordis": "^4.0.1",
+        "node-addon-require-builtin": "^0.1.4"
+      },
+      "peerDependenciesMeta": {
+        "node-addon-require-builtin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@deepseek-ai/cosmokit": {
+      "version": "1.8.2",
+      "license": "MIT"
     },
     "node_modules/@deepseek-ai/dsh-agent": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-agent/-/dsh-agent-0.0.1-rc.1.tgz",
-      "integrity": "sha512-x9tQv9QtznhvANUIYp5KtGUAMCxIkCiEhdMwYeUULJ7SkOYbgr7z/6yG/67Z+aaGglVrQ68rMKgk+zj0hlUI+Q==",
+      "version": "0.0.1-rc.5",
       "license": "BSD-3-Clause",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-session": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-system-prompt": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-type-meta": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-session": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-system-prompt": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-typert-protocol": "^0.0.1-rc.5"
       }
     },
     "node_modules/@deepseek-ai/dsh-attachment": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-attachment/-/dsh-attachment-0.0.1-rc.1.tgz",
-      "integrity": "sha512-zBBw6h+YKOf7U8uEZezbFUjLsA8VU1GfCIUonAZHG2hWDWhWbrGaoO9fL8KyncEDSWMLMoIoGo+ZxDEPVJZYOA==",
+      "version": "0.0.1-rc.5",
       "license": "BSD-3-Clause",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-brand": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
       }
     },
     "node_modules/@deepseek-ai/dsh-brand": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-brand/-/dsh-brand-0.0.1-rc.1.tgz",
-      "integrity": "sha512-XhwNAugG/baCVA+BMMvjihYi9XMLcDUew3G63i+ATWIZCvpx8CghbgcV93DEeMH2sqhNuQAssmHgXkpRld3gyQ==",
+      "version": "0.0.1-rc.5",
       "license": "BSD-3-Clause",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
       }
     },
     "node_modules/@deepseek-ai/dsh-code-runtime": {
       "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-code-runtime/-/dsh-code-runtime-0.0.1-rc.1.tgz",
-      "integrity": "sha512-lfHc2HevlivlnKWt876s1rOSov5PyR9tPpPiQFEs46jREF5JjwMdE8yTUbpEnBt9A97NZ+vKl2o7LbqVZPSSxg==",
       "license": "BSD-3-Clause",
       "peer": true,
       "peerDependencies": {
@@ -103,92 +108,78 @@
       }
     },
     "node_modules/@deepseek-ai/dsh-invariants": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-invariants/-/dsh-invariants-0.0.1-rc.1.tgz",
-      "integrity": "sha512-ZoGCGColviu3Tkdnv9hMkgBE4eg0hAz5GXR/knqRf7mJUeBlTCya2dIckYlqekYmp5L+1AeWxf9j+Lv1YRcvXw==",
+      "version": "0.0.1-rc.5",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1-rc.1"
+        "@deepseek-ai/schemastery": "^3.18.1-rc.4"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.1-rc.4"
       }
     },
     "node_modules/@deepseek-ai/dsh-llm": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-llm/-/dsh-llm-0.0.1-rc.1.tgz",
-      "integrity": "sha512-mRJj07IQNfRReGrhpMpL8AONiYKqfwzxvepg/ut9Wkj8oH2BuoftPS4cMnnXFFCUlYql04/sezwDLriYks/bmw==",
+      "version": "0.0.1-rc.5",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1-rc.1"
+        "@deepseek-ai/schemastery": "^3.18.1-rc.4"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-attachment": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-timeout": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-attachment": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-brand": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-timeout": "^0.0.1-rc.5"
       }
     },
     "node_modules/@deepseek-ai/dsh-scope": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-scope/-/dsh-scope-0.0.1-rc.1.tgz",
-      "integrity": "sha512-XJa74NACc/285kF7Tak2nA+dlNpSTN77cV9SMhl75Bzu1y7p9+VgSMJfd6ydBsYVtDcAwzbon4wSS1u9AiI5VQ==",
+      "version": "0.0.1-rc.5",
       "license": "BSD-3-Clause",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
       }
     },
     "node_modules/@deepseek-ai/dsh-session": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-session/-/dsh-session-0.0.1-rc.1.tgz",
-      "integrity": "sha512-P3xE+0jDPMImdWhRi3e5ByhkA6LFTiabQwcK+Ofy763tWajDsadWpvONkc5Imd61thpVtXzH3uu25rZFvT5cfw==",
+      "version": "0.0.1-rc.5",
       "license": "BSD-3-Clause",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-brand": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-type-meta": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-brand": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-typert-protocol": "^0.0.1-rc.5"
       }
     },
     "node_modules/@deepseek-ai/dsh-system-prompt": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-system-prompt/-/dsh-system-prompt-0.0.1-rc.1.tgz",
-      "integrity": "sha512-xNHVjV8oBueTbYe2i7OmxW3W4SDlMUo2ZxJiLeVQdjx8jolzYHyF+EgaYeOJmF1BJmgPbyc1biCZetSFSWY9TA==",
+      "version": "0.0.1-rc.5",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/schemastery": "^3.18.1-rc.1"
+        "@deepseek-ai/schemastery": "^3.18.1-rc.4"
       },
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-llm": "^0.0.1-rc.1",
-        "@deepseek-ai/dsh-scope": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-llm": "^0.0.1-rc.5",
+        "@deepseek-ai/dsh-scope": "^0.0.1-rc.5"
       }
     },
     "node_modules/@deepseek-ai/dsh-timeout": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-timeout/-/dsh-timeout-0.0.1-rc.1.tgz",
-      "integrity": "sha512-lIMhY/JqA+eLpXXUN33xA7mlAYeHTDTWfcJ3CmEtplvGnvpDAHQ6oPeFs9JtWcfKbuNDZFMNutyhD0qoRkFQeg==",
+      "version": "0.0.1-rc.5",
       "license": "BSD-3-Clause",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
       }
     },
     "node_modules/@deepseek-ai/dsh-tools": {
       "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-tools/-/dsh-tools-0.0.1-rc.1.tgz",
-      "integrity": "sha512-mrtq+UXc6UVidrGo4GM8RAH0Gqc4iFOmtPeQAz59Phhjl3EmzkFI0Mo6dQlHQamrc2J9jppPtGtUzW9qHmwxDQ==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -206,21 +197,17 @@
         "@deepseek-ai/dsh-user-approval": "^0.0.1-rc.1"
       }
     },
-    "node_modules/@deepseek-ai/dsh-type-meta": {
-      "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-type-meta/-/dsh-type-meta-0.0.1-rc.1.tgz",
-      "integrity": "sha512-cO2rpWTHa4WopJJYU795pmN+0N4siP9b2c0qxawm8X+jB1Tk33GbROh6fqcOoF3mBLvRYmxjLD0Qk4IbZfphxQ==",
+    "node_modules/@deepseek-ai/dsh-typert-protocol": {
+      "version": "0.0.1-rc.5",
       "license": "BSD-3-Clause",
       "peer": true,
       "peerDependencies": {
-        "@deepseek-ai/cordis": "^4.0.1-rc.1",
-        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.1"
+        "@deepseek-ai/cordis": "^4.0.1-rc.4",
+        "@deepseek-ai/dsh-invariants": "^0.0.1-rc.5"
       }
     },
     "node_modules/@deepseek-ai/dsh-user-approval": {
       "version": "0.0.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/dsh-user-approval/-/dsh-user-approval-0.0.1-rc.1.tgz",
-      "integrity": "sha512-28J7iT2fl9I0haeCRwVIWqhFBO3xG+A1GAdfhLJG/9YkB0F3Cs6FUoRtNQ7pjxkJ6QzELY/gRBE7axCP0ETHcA==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -238,20 +225,16 @@
       }
     },
     "node_modules/@deepseek-ai/schemastery": {
-      "version": "3.18.1-rc.1",
-      "resolved": "https://registry.npmjs.org/@deepseek-ai/schemastery/-/schemastery-3.18.1-rc.1.tgz",
-      "integrity": "sha512-gilia4mY6S/j6oFYsn4x2Ve9K6QfvzTgqJntkty0wFsKjTYHQ6e2WDvXLMw48t75WRBhpLt+ZpFm3GHmTWkNMw==",
+      "version": "3.18.1",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@deepseek-ai/cosmokit": "^1.8.2-rc.1",
+        "@deepseek-ai/cosmokit": "^1.8.2",
         "@standard-schema/spec": "^1.1.0"
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.144.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
-      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "version": "0.146.0",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -260,8 +243,6 @@
     },
     "node_modules/@quansync/fs": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-1.0.0.tgz",
-      "integrity": "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -271,10 +252,27 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
-      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
       "cpu": [
         "arm64"
       ],
@@ -289,9 +287,7 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "version": "1.2.5",
       "cpu": [
         "arm64"
       ],
@@ -306,9 +302,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
       "cpu": [
         "x64"
       ],
@@ -323,9 +319,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
-      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
       "cpu": [
         "x64"
       ],
@@ -340,9 +336,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
-      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
       "cpu": [
         "arm"
       ],
@@ -357,13 +353,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
-      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -374,13 +373,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
-      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -391,13 +393,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
-      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -408,13 +413,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
-      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -425,13 +433,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
-      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -442,13 +453,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
-      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -459,9 +473,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
-      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
       "cpu": [
         "arm64"
       ],
@@ -476,9 +490,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
-      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
       "cpu": [
         "arm64"
       ],
@@ -493,9 +507,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
-      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
       "cpu": [
         "x64"
       ],
@@ -511,22 +525,16 @@
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@types/node": {
       "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -549,8 +557,6 @@
     },
     "node_modules/@yuku-codegen/binding-darwin-arm64": {
       "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-darwin-arm64/-/binding-darwin-arm64-0.8.7.tgz",
-      "integrity": "sha512-/u+REDMI4a0/lsJXTM4c53/w31OGZLOReZIyg62uhgLs0kc8NHsj/nOcxTdlQjq5gi0zhdkccD9LaLTXcdzPvw==",
       "cpu": [
         "arm64"
       ],
@@ -597,6 +603,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -611,6 +620,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -625,6 +637,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -639,6 +654,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -653,6 +671,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -667,6 +688,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -717,8 +741,6 @@
     },
     "node_modules/@yuku-parser/binding-darwin-arm64": {
       "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@yuku-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.8.7.tgz",
-      "integrity": "sha512-Re0RHelKLnjEURulY2/KxW+Ngb8zuNA4BRZuMwgGQNzVumT6u4U2N2hc01oeYVNVof0i7GrXE4UCNBgbpRRnjQ==",
       "cpu": [
         "arm64"
       ],
@@ -765,6 +787,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -779,6 +804,9 @@
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -793,6 +821,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -807,6 +838,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -821,6 +855,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -835,6 +872,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -871,15 +911,11 @@
     },
     "node_modules/@yuku-toolchain/types": {
       "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@yuku-toolchain/types/-/types-0.8.7.tgz",
-      "integrity": "sha512-2Z53dNxAJL6UvFoIrDZvYf3zlO8s4VJK4O2hhaB4mXVwwpX/7ajtss3cmfqKvamlNLWyt9FSWs4eoYdlbxpnHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ansis": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
-      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -888,8 +924,6 @@
     },
     "node_modules/cac": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
-      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -897,49 +931,16 @@
       }
     },
     "node_modules/cordis": {
-      "version": "4.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/cordis/-/cordis-4.0.0-rc.8.tgz",
-      "integrity": "sha512-vXaYK6XZJlIFTnODp4Rd973Qnd/gm3cwFzWsMTaeu6cQQheA7N+aA0GqHRNl0cFIrxMXWU8dst1ZXHlUQvfyRw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "cosmokit": "^1.8.1"
-      },
-      "bin": {
-        "cordis": "bin.js"
-      },
-      "peerDependencies": {
-        "@cordisjs/plugin-include": "^1.0.4",
-        "@cordisjs/plugin-loader": "^1.0.0-rc.5"
-      },
-      "peerDependenciesMeta": {
-        "@cordisjs/plugin-include": {
-          "optional": true
-        },
-        "@cordisjs/plugin-loader": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cosmokit": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/cosmokit/-/cosmokit-1.8.1.tgz",
-      "integrity": "sha512-PDBv4l90xZKrUsZ0vtoycgZpO/j4iFsqJXrAxsyBDsnQRI7ZMJXIjgDJsKNjd5L8jnVnnlrDCdhkFbTncgCVjQ==",
-      "license": "MIT",
-      "peer": true
+      "resolved": "node_modules/@deepseek-ai/cordis",
+      "link": true
     },
     "node_modules/defu": {
       "version": "6.1.7",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
-      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/dts-resolver": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/dts-resolver/-/dts-resolver-3.0.0.tgz",
-      "integrity": "sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -959,8 +960,6 @@
     },
     "node_modules/empathic": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
-      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -969,8 +968,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -987,8 +984,6 @@
     },
     "node_modules/get-tsconfig": {
       "version": "5.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-5.0.0-beta.5.tgz",
-      "integrity": "sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1003,15 +998,11 @@
     },
     "node_modules/hookable": {
       "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
-      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/import-without-cache": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/import-without-cache/-/import-without-cache-0.4.0.tgz",
-      "integrity": "sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1023,8 +1014,6 @@
     },
     "node_modules/obug": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
-      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -1036,9 +1025,7 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1050,8 +1037,6 @@
     },
     "node_modules/quansync": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/quansync/-/quansync-1.0.0.tgz",
-      "integrity": "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==",
       "dev": true,
       "funding": [
         {
@@ -1067,8 +1052,6 @@
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1076,13 +1059,11 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
-      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "version": "1.2.5",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.144.0",
+        "@oxc-project/types": "=0.146.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -1092,26 +1073,25 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.2.4",
-        "@rolldown/binding-darwin-arm64": "1.2.4",
-        "@rolldown/binding-darwin-x64": "1.2.4",
-        "@rolldown/binding-freebsd-x64": "1.2.4",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
-        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
-        "@rolldown/binding-linux-arm64-musl": "1.2.4",
-        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
-        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
-        "@rolldown/binding-linux-x64-gnu": "1.2.4",
-        "@rolldown/binding-linux-x64-musl": "1.2.4",
-        "@rolldown/binding-openharmony-arm64": "1.2.4",
-        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
-        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
       }
     },
     "node_modules/rolldown-plugin-dts": {
       "version": "0.27.14",
-      "resolved": "https://registry.npmjs.org/rolldown-plugin-dts/-/rolldown-plugin-dts-0.27.14.tgz",
-      "integrity": "sha512-ZvuDDwoIpRK9RPxDXratCpklFO9QZZWndf/sd0VBFb4LEj0jj07UcHK9OCh7V4XiFz2Z89ziyBC2K6tJiDjrbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1151,20 +1131,11 @@
       }
     },
     "node_modules/schemastery": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/schemastery/-/schemastery-3.18.0.tgz",
-      "integrity": "sha512-Jw2uxjoyyqc/yeurmChUEc/jbi8GsrdXV/KmqRUDZXJAXAmrJiPsz8vKa17l/VckyzljHZ9oGaul443CQiXxtA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "cosmokit": "^1.8.1"
-      }
+      "resolved": "node_modules/@deepseek-ai/schemastery",
+      "link": true
     },
     "node_modules/tinyexec": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
-      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1173,8 +1144,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1190,8 +1159,6 @@
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1200,8 +1167,6 @@
     },
     "node_modules/tsdown": {
       "version": "0.22.14",
-      "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.22.14.tgz",
-      "integrity": "sha512-ule7Y+fsAN2iZbLDoo7C4KYljFJNJJ+fLshyn+9gozeTspVersWHxwdGB+Dm2hzA38s6muFnUTl0jK3vJm9ifQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1273,8 +1238,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1287,8 +1250,6 @@
     },
     "node_modules/unconfig-core": {
       "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.5.0.tgz",
-      "integrity": "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1301,15 +1262,11 @@
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/verkit": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/verkit/-/verkit-0.3.2.tgz",
-      "integrity": "sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1321,8 +1278,6 @@
     },
     "node_modules/yuku-ast": {
       "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/yuku-ast/-/yuku-ast-0.8.7.tgz",
-      "integrity": "sha512-h6+4bDfyootiMB9vckk5uKo5r5j0GHrkr17FQTDNfEsFT3DWlN9uu1HJwQwc64pgmLCI945fWM3lbTIqxjT3GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1331,8 +1286,6 @@
     },
     "node_modules/yuku-codegen": {
       "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/yuku-codegen/-/yuku-codegen-0.8.7.tgz",
-      "integrity": "sha512-adwDZSh8oVDzhE6Du9PwVWxcOxeV0e2EVhUuMKWfhSY4wkrDq9eqixlxFF3l/XGUV1E7UFzhpz9393MUumkyNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1355,8 +1308,6 @@
     },
     "node_modules/yuku-parser": {
       "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/yuku-parser/-/yuku-parser-0.8.7.tgz",
-      "integrity": "sha512-vRD9nwt4L3aYpxNqeSC4WqLv58xrXef0Ong1Mc45CTXTIpvLafx7JO05sczmQZwdLEZvywrLOGdNC5+Rp5N1BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/injector/package.json
+++ b/injector/package.json
@@ -43,6 +43,7 @@
     "schemastery": "^3.18.0"
   },
   "devDependencies": {
+    "@deepseek-ai/cordis-plugin-loader": "^1.0.2",
     "@types/node": "^24.13.3",
     "tsdown": "^0.22.14",
     "typescript": "^5.9.3"


### PR DESCRIPTION
Fixes #74. Supersedes the docs-only workaround noted there.

Cherry-picked from @profanitys1's `local-patches` branch (original author kept), rebased onto `main`
with the INSTALL.md §3 conflict resolved in favour of the current auto-build text from #40.

## What was broken

`npm ci` / `npm i` in `injector/` died on a package that does not exist on npm:

```
npm error 404  @deepseek-ai/dsh-type-meta@0.0.1-rc.1
```

Two independent causes, both fixed here:

- the committed lockfile **pinned** `@deepseek-ai/dsh-type-meta@0.0.1-rc.1`, so any lock-driven install
  was impossible regardless of flags
- `@deepseek-ai/cordis-plugin-loader` is imported by `src/index.ts` but was declared nowhere, so fresh
  trees hit `TS2307` on typecheck

## Changes

- `package-lock.json` regenerated at v0.3.3 — no `dsh-type-meta` pin, no `link:` entries, no absolute
  paths, so it is portable
- `package.json` — declare `@deepseek-ai/cordis-plugin-loader@^1.0.2` in devDependencies
- `INSTALL.md` §3 — document the source-build route: dependency install, the fork-`d.ts` requirement
  for `tsc` (public-registry cordis d.ts is broken under NodeNext, the packaged app bundle strips the
  fork's), and the `prepare.mjs` stale-`lib/` trap (`rm -rf lib` to force a rebuild)

## Verification

```
rm -rf node_modules lib && npm ci --no-audit --no-fund
✔ Build complete in 93ms
added 54 packages in 3s

ls lib/   # client.js  client.js.map  index.js  index.js.map
```

`npm ci` from a clean clone now works and the `prepare` hook produces both bundles, which is what
`README.en.md` claims for #40.
