### PR TITLE
docs: add DeepSeek Harness Handbook reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Copy-Item -Recurse .\preset\router-spec $target
 - 注入器引导（规范铁律 10 条）：`injector/README.md`
 - 路由预设论文与实验：`preset/docs/paper.md` + `preset/docs/experiments.md`（P1-P23）
 - 仓库结构迁移（submodule → 直接文件）：[docs/FLATTEN-MIGRATION.md](docs/FLATTEN-MIGRATION.md)
+- DeepSeek Harness Agent/runtime 故障与取证手册：[deepseek-harness-handbook](https://github.com/sandbaseai/deepseek-harness-handbook)（插件、MCP、Session、沙箱、审批和跨平台排障）
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

- Add the independent DeepSeek Harness Handbook to the README documentation section.
- The handbook complements routing-suite experiments with source-backed Agent/runtime and cross-platform troubleshooting guidance.

## Current reference

- Handbook: https://github.com/sandbaseai/deepseek-harness-handbook
- Latest release: v0.5.285
- Coverage: 159 English canonical guides / 174 localized documents

This is a single documentation-only bullet; no routing or injector behavior changes.
