### PR TITLE
fix: build root git dependency before packing

### DIFF
--- a/injector/.npmignore
+++ b/injector/.npmignore
@@ -1,0 +1,4 @@
+# npm otherwise reuses .gitignore and drops the lib/ output built by prepare.
+node_modules/
+*.tsbuildinfo
+*.tgz

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.3.3",
   "description": "dsh-routing-suite 分发入口：DSH 超级模组注入器（BepInEx 式运行时注入，免重启）+ router-standard 预设仓库。插件入口为 injector/，预设位于 preset/。",
   "private": true,
+  "scripts": {
+    "prepare": "node injector/scripts/prepare.mjs"
+  },
   "type": "module",
   "main": "./injector/lib/index.js",
   "types": "./injector/lib/types/index.d.ts",

--- a/test/root-package-prepare.test.mjs
+++ b/test/root-package-prepare.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+
+test('the root package runs the injector prepare hook for git installs', () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'dsh-routing-suite-prepare-'))
+
+  try {
+    mkdirSync(join(fixture, 'injector', 'scripts'), { recursive: true })
+    mkdirSync(join(fixture, 'injector', 'lib'), { recursive: true })
+    copyFileSync(join(repoRoot, 'package.json'), join(fixture, 'package.json'))
+    copyFileSync(
+      join(repoRoot, 'injector', 'scripts', 'prepare.mjs'),
+      join(fixture, 'injector', 'scripts', 'prepare.mjs'),
+    )
+    writeFileSync(join(fixture, 'injector', 'lib', 'index.js'), '')
+    writeFileSync(join(fixture, 'injector', 'lib', 'client.js'), '')
+
+    const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    const result = spawnSync(npm, ['run', 'prepare'], {
+      cwd: fixture,
+      encoding: 'utf8',
+      shell: process.platform === 'win32',
+    })
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+    assert.match(result.stdout, /\[prepare\] lib\/ already built/)
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})
+
+test('the prepared injector entry points are included in the package', () => {
+  const fixture = mkdtempSync(join(tmpdir(), 'dsh-routing-suite-pack-'))
+
+  try {
+    mkdirSync(join(fixture, 'injector', 'lib'), { recursive: true })
+    copyFileSync(join(repoRoot, 'package.json'), join(fixture, 'package.json'))
+    copyFileSync(join(repoRoot, 'injector', '.gitignore'), join(fixture, 'injector', '.gitignore'))
+
+    const npmIgnore = join(repoRoot, 'injector', '.npmignore')
+    if (existsSync(npmIgnore)) {
+      copyFileSync(npmIgnore, join(fixture, 'injector', '.npmignore'))
+    }
+
+    writeFileSync(join(fixture, 'injector', 'lib', 'index.js'), '')
+    writeFileSync(join(fixture, 'injector', 'lib', 'client.js'), '')
+
+    const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+    const result = spawnSync(npm, ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+      cwd: fixture,
+      encoding: 'utf8',
+      shell: process.platform === 'win32',
+    })
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+    const paths = JSON.parse(result.stdout)[0].files.map(({ path }) => path)
+    assert.ok(paths.includes('injector/lib/index.js'), 'package omits injector/lib/index.js')
+    assert.ok(paths.includes('injector/lib/client.js'), 'package omits injector/lib/client.js')
+  } finally {
+    rmSync(fixture, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

- Fixes: The documented github:yjh051108/dsh-routing-suite install cannot load the package because its declared injector/lib/index.js entry is absent.
- Root cause: The root package does not invoke the existing nested prepare builder, and npm then reuses injector/.gitignore while packing the Git dependency, excluding the generated lib directory.

Fixes #80. Related: #78 (the suite symptom is covered here; its standalone registry blocker is separate).

## Regression evidence

- Before: `node --test test/root-package-prepare.test.mjs` exited `1`

- After: `node --test test/root-package-prepare.test.mjs` exited `0`

## Verification

- `npm run prepare`
- `npm pack --dry-run --json`
- `node --check test/root-package-prepare.test.mjs && node --check injector/scripts/prepare.mjs && validate package.json`
- `node preset/router-standard/router-bootstrap-v34.selftest.mjs`

The unrelated full preset suite currently hits the known millisecond-boundary failure in #73 (49/50 on this run); #75 already contains its fix. This change does not touch preset code.

## Scope

- 3 files changed, +76 / -0 lines
