### PR TITLE
Use sessionEvents helper across router presets

### DIFF
--- a/preset/router-spec/router-bootstrap-v10.mjs
+++ b/preset/router-spec/router-bootstrap-v10.mjs
@@ -29,7 +29,7 @@
 
 import {
   applyPersona, bandFor, bandOf, coreFor, parseMode, personaFor, sessionMode, testinessFor, clamp01,
-  classifyTask, extractText, isComplexTask,
+  classifyTask, extractText, isComplexTask, sessionEvents
 } from './router-core-v10.mjs'
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -142,7 +142,7 @@ export function apply(ctx, config) {
       core = new Set(legacyCore(mode))
     }
 
-    if (session.events.some((event) => event.type === 'tool/call')) {
+    if (sessionEvents(session).some((event) => event.type === 'tool/call')) {
       // Promoted (#44): the RL-standard first-turn trim was a FIRST-REQUEST-ONLY
       // minimization. After the first durable tool/call the router stops
       // touching anything — standard mode restores the full sections/contexts;
@@ -223,7 +223,7 @@ export function apply(ctx, config) {
       const id = `router-guide-${message.id}`
       // Resume safety: a previously appended guide for the same message id
       // is already durable in the transcript — never inject twice.
-      if (session.events.some((event) => event.type === 'user/message' && event.data?.id === id)) continue
+      if (sessionEvents(session).some((event) => event.type === 'user/message' && event.data?.id === id)) continue
       guides.push({
         id,
         role: 'user',

--- a/preset/router-spec/router-core-v10.mjs
+++ b/preset/router-spec/router-core-v10.mjs
@@ -158,10 +158,20 @@ export function classifyTask(text) {
  * user-origin message exists.
  */
 export function sessionMode(session) {
-  const events = session.events
+  const events = session.events || (typeof session.snapshotEvents === 'function' ? session.snapshotEvents() : [])
   const userMsg = events.find((e) => e.type === 'user/message' && (e.data?.source?.kind === 'user' || e.data?.source?.kind === undefined))
     ?? events.find((e) => e.type === 'user/message')
   return classifyTask(extractText(userMsg?.data))
+}
+
+// 新增辅助（router-core）：
+export function sessionEvents(session) {
+  if (!session) return []
+  if (Array.isArray(session.events)) return session.events
+  if (typeof session.snapshotEvents === 'function') {
+    try { return session.snapshotEvents() } catch { return [] }
+  }
+  return []
 }
 
 export function extractText(data) {

--- a/preset/router-standard/router-bootstrap-v34.mjs
+++ b/preset/router-standard/router-bootstrap-v34.mjs
@@ -15,7 +15,7 @@
  */
 
 import {
-  bandFor, sessionMode, extractText, isComplexTask,
+  bandFor, sessionMode, extractText, isComplexTask, sessionEvents
 } from './router-core-v34.mjs'
 import { join, dirname } from 'node:path'
 import { homedir, tmpdir } from 'node:os'
@@ -631,7 +631,7 @@ export function apply(ctx, config) {
       : undefined
     if (selectedModel?.model) sessionModels.set(session.id, selectedModel)
 
-    const promoted = session.events.some((event) => event.type === 'tool/call')
+    const promoted = sessionEvents(session).some((event) => event.type === 'tool/call')
     const planSection = (assembled.sections || []).find((s) => /plan/i.test(s.name))
     const baseSections = planSection
       ? [planSection, { name: 'router-persona', text: RL_PERSONA, order: 0 }]
@@ -676,7 +676,7 @@ export function apply(ctx, config) {
     const sid = agent.session.id
     const st = (ensureStage()[sid] ??= { stage: 0, guided: false })
     const stageAt = st.stageAtTime ?? 0
-    const toolCalls = (agent.session.events || []).filter((e) => (e.time === undefined || e.time >= stageAt) && (e.type === 'tool/call' || e.type === 'tool/code-dispatch')).map((e) => ({ name: e.data?.name || e.data?.toolName || '', args: toolArgs(e.data) }))
+    const toolCalls = sessionEvents(agent.session).filter((e) => (e.time === undefined || e.time >= stageAt) && (e.type === 'tool/call' || e.type === 'tool/code-dispatch')).map((e) => ({ name: e.data?.name || e.data?.toolName || '', args: toolArgs(e.data) }))
     // v1.17.2：被拒的锁定工具调用（如阶段 0 调 bash → unknown tool）不算行为信号——
     // 只有当前阶段真实可调（view.visible）的工具调用才触发直达推进。
     let advanceCalls = toolCalls
@@ -1106,7 +1106,7 @@ export function apply(ctx, config) {
       if (!theAgent) throw new Error('goal tools require a calling agent')
       const agentsSvc = ctx.get('agents')
       if (!agentsSvc || agentsSvc.get(theAgent.id) !== theAgent || theAgent.status !== 'running' || (agentsSvc.currentInitiator && agentsSvc.currentInitiator() !== theAgent)) throw new Error('goal tools require the exact live calling agent inside its active driver')
-      const evs = theAgent.session.events || []
+      const evs = sessionEvents(theAgent.session)
       for (let i = evs.length - 1; i >= 0; i--) {
         if (evs[i]?.type === 'turn/end') throw new Error('goal tools require an open model turn')
         if (evs[i]?.type === 'turn/start') return { agent: theAgent, events: evs.slice(i + 1) }

--- a/preset/router-standard/router-core-v34.mjs
+++ b/preset/router-standard/router-core-v34.mjs
@@ -147,11 +147,21 @@ export function classifyTask(text) {
 
 /** Per-session mode derived from durable events (resume-safe). */
 export function sessionMode(session) {
-  const events = session.events || []
+  const events = session.events || (typeof session.snapshotEvents === 'function' ? session.snapshotEvents() : [])
   // #13：跳过插件注入的消息（approval/runtime-context/router 引导）——它们不代表任务
   const userMsg = events.find((e) => e.type === 'user/message' && e.data?.source?.kind !== 'plugin')
     ?? events.find((e) => e.type === 'user/message')
   return classifyTask(extractText(userMsg?.data))
+}
+
+// 新增辅助（router-core）：
+export function sessionEvents(session) {
+  if (!session) return []
+  if (Array.isArray(session.events)) return session.events
+  if (typeof session.snapshotEvents === 'function') {
+    try { return session.snapshotEvents() } catch { return [] }
+  }
+  return []
 }
 
 export function extractText(data) {


### PR DESCRIPTION
Add a shared `sessionEvents(session)` helper in both router core modules to normalize event access (`session.events` with `snapshotEvents()` fallback), then switch bootstrap logic to use it for tool-call promotion checks, guide dedupe, stage advancement, and goal-tool turn scanning. This makes routing behavior more robust in resumed sessions where events may only be available via snapshots.

fix #84