### PR TITLE
fix(install): UTF-8 BOM for Windows PowerShell 5.1 (#16)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-# dsh-routing-suite 一键安装（Windows PowerShell）
+﻿# dsh-routing-suite 一键安装（Windows PowerShell）
 # 步骤：1) 装配注入器  2) 安装 router-standard / router-spec 预设  3) 提示重启
 $ErrorActionPreference = 'Stop'
 $root = Split-Path -Parent $MyInvocation.MyCommand.Path


### PR DESCRIPTION
Adds UTF-8 BOM to install.ps1 so PS 5.1 (ANSI default) parses the non-ASCII comments (issue #16/#25).