### PR TITLE
fix(injector): restore ~/deepseek-harness in checkout probe candidates

### DIFF
--- a/injector/src/index.ts
+++ b/injector/src/index.ts
@@ -2754,6 +2754,7 @@ export function apply(ctx: AppContext, config: Config): void {
     const env = (process.env as Record<string, string | undefined>).DSH_CHECKOUT
     if (env && existsSync(join(env, 'packages'))) return env
     const candidates = [
+      join(homedir(), 'deepseek-harness'),
       join(homedir(), 'dsh-harness'),
       join(homedir(), 'dsh'),
       join(homedir(), '.dsh', 'dsh-harness'),


### PR DESCRIPTION
## 问题

`detectCheckout()` 探测 DSH checkout 的候选列表在 c08136a 中丢掉了 `~/deepseek-harness`：

- v0.3.3（已发布）候选为 `~/deepseek-harness` → `~/dsh-harness` → `~/dsh` → `~/.dsh/dsh-harness`
- c08136a 起只剩后三个（`~/deepseek-harness` 被删除）

而同一文件里 scaffold 生成的 build.sh 模板仍写着 "home 下 deepseek-harness / dsh-harness"，删漏了半边。

## 影响

当部署满足以下两个条件时：

1. `DSH_CHECKOUT` 环境变量未设置（web 进程常见情况）
2. 本机 checkout 目录名为 `~/deepseek-harness`（而非 `dsh-harness`/`dsh`）

`dev_build_plugin` 报 `ERROR: 未找到 DSH checkout（设置 DSH_CHECKOUT 环境变量）`，`dev_self_test` 第一步 `checkout 探测 — 无 DSH_CHECKOUT` 直接 FAIL。注入器自检 8/8 的验收（v0.3.3 发布口径）在默认路径下无法达成。

## 修复

恢复 v0.3.3 的候选顺序（`deepseek-harness` 前置），一行改动：

```diff
     const candidates = [
+      join(homedir(), 'deepseek-harness'),
       join(homedir(), 'dsh-harness'),
       join(homedir(), 'dsh'),
       join(homedir(), '.dsh', 'dsh-harness'),
     ]
```

## 验证

本机（checkout 位于 `~/deepseek-harness`、无 DSH_CHECKOUT）打上此补丁后：

- `dev_self_test` 恢复 **8/8 PASS**（含测试插件构建）
- `dev_build_plugin` 正常探测 checkout

> 附：若可接受，建议同时把 scaffold 模板里 build.sh 的 HOMEDIR 探测循环也补上 `$HOME/deepseek-harness`（同文件约 52-55 行），保持两处一致。